### PR TITLE
fix(AG-3472): allow omission of scanner credentials - skip cloudscanner in those cases

### DIFF
--- a/modules/tenant/README.md
+++ b/modules/tenant/README.md
@@ -97,15 +97,15 @@ No modules.
 | <a name="input_azure_tenant_id"></a> [azure\_tenant\_id](#input\_azure\_tenant\_id) | The Azure Tenant that will be onboarded to the Upwind organization. | `string` | `""` | no |
 | <a name="input_create_organizational_credentials"></a> [create\_organizational\_credentials](#input\_create\_organizational\_credentials) | Set to true to create organizational credentials for the management groups pending onboarding. Needs to be set to false before destroying module. | `bool` | `true` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to append to all resources created by this module. | `string` | `""` | no |
-| <a name="input_scanner_client_id"></a> [scanner\_client\_id](#input\_scanner\_client\_id) | The client ID used for authentication with the Upwind CloudScanner Service. | `string` | n/a | yes |
-| <a name="input_scanner_client_secret"></a> [scanner\_client\_secret](#input\_scanner\_client\_secret) | The client secret for authentication with the Upwind CloudScanner Service. | `string` | n/a | yes |
+| <a name="input_scanner_client_id"></a> [scanner\_client\_id](#input\_scanner\_client\_id) | The client ID used for authentication with the Upwind CloudScanner Service. | `string` | `""` | no |
+| <a name="input_scanner_client_secret"></a> [scanner\_client\_secret](#input\_scanner\_client\_secret) | The client secret for authentication with the Upwind CloudScanner Service. | `string` | `""` | no |
 | <a name="input_skip_app_service_provider_registration"></a> [skip\_app\_service\_provider\_registration](#input\_skip\_app\_service\_provider\_registration) | Set to true to skip the Microsoft.App provider registration. NOTE: The Microsoft.App provider must be registered in the subscription before deployments from Upwind backends can succeed. | `bool` | `false` | no |
 | <a name="input_upwind_auth_endpoint"></a> [upwind\_auth\_endpoint](#input\_upwind\_auth\_endpoint) | The Authentication API endpoint. | `string` | `"https://auth.upwind.io"` | no |
 | <a name="input_upwind_client_id"></a> [upwind\_client\_id](#input\_upwind\_client\_id) | The client ID used for authentication with the Upwind Authorization Service. | `string` | n/a | yes |
 | <a name="input_upwind_client_secret"></a> [upwind\_client\_secret](#input\_upwind\_client\_secret) | The client secret for authentication with the Upwind Authorization Service. | `string` | n/a | yes |
 | <a name="input_upwind_integration_endpoint"></a> [upwind\_integration\_endpoint](#input\_upwind\_integration\_endpoint) | The Integration API endpoint. | `string` | `"https://integration.upwind.io"` | no |
 | <a name="input_upwind_organization_id"></a> [upwind\_organization\_id](#input\_upwind\_organization\_id) | The identifier of the Upwind organization to integrate with. | `string` | n/a | yes |
-| <a name="input_upwind_region"></a> [upwind\_region](#input\_upwind\_region) | The region where the Upwind components will be deployed. | `string` | `"us"` | no |
+| <a name="input_upwind_region"></a> [upwind\_region](#input\_upwind\_region) | The region where the Upwind components will be deployed. Must be 'us', 'eu' or 'me' | `string` | `"us"` | no |
 
 ## Outputs
 

--- a/modules/tenant/cloudscanner_general.tf
+++ b/modules/tenant/cloudscanner_general.tf
@@ -61,6 +61,7 @@ resource "null_resource" "register_app_service_provider" {
 }
 
 resource "azurerm_resource_group" "orgwide_resource_group" {
+  count    = local.cloudscanner_enabled ? 1 : 0
   name     = "upwind-cs-rg-${var.upwind_organization_id}"
   location = var.azure_cloudscanner_location
 }

--- a/modules/tenant/cloudscanner_iam.tf
+++ b/modules/tenant/cloudscanner_iam.tf
@@ -50,8 +50,8 @@ resource "azurerm_role_assignment" "deployer" {
 
 resource "azurerm_user_assigned_identity" "worker_user_assigned_identity" {
   count               = local.cloudscanner_enabled ? 1 : 0
-  resource_group_name = azurerm_resource_group.orgwide_resource_group.name
-  location            = azurerm_resource_group.orgwide_resource_group.location
+  resource_group_name = azurerm_resource_group.orgwide_resource_group[0].name
+  location            = azurerm_resource_group.orgwide_resource_group[0].location
   name                = "upwind-cs-vmss-identity-${var.upwind_organization_id}"
 }
 
@@ -108,8 +108,8 @@ resource "azurerm_role_assignment" "storage_reader" {
 
 resource "azurerm_user_assigned_identity" "scaler_user_assigned_identity" {
   count               = local.cloudscanner_enabled ? 1 : 0
-  resource_group_name = azurerm_resource_group.orgwide_resource_group.name
-  location            = azurerm_resource_group.orgwide_resource_group.location
+  resource_group_name = azurerm_resource_group.orgwide_resource_group[0].name
+  location            = azurerm_resource_group.orgwide_resource_group[0].location
   name                = "upwind-cs-scaler-function-identity-${var.upwind_organization_id}"
 }
 
@@ -164,8 +164,8 @@ resource "azurerm_role_assignment" "cloudscanner_scaler" {
 # Create an identity that will have key vault service encryption access subscription wide
 resource "azurerm_user_assigned_identity" "key_vault_access" {
   count               = local.cloudscanner_enabled ? 1 : 0
-  resource_group_name = azurerm_resource_group.orgwide_resource_group.name
-  location            = azurerm_resource_group.orgwide_resource_group.location
+  resource_group_name = azurerm_resource_group.orgwide_resource_group[0].name
+  location            = azurerm_resource_group.orgwide_resource_group[0].location
   name                = "upwind-cs-disk-encryption-identity-${var.upwind_organization_id}"
 }
 

--- a/modules/tenant/cloudscanner_secrets.tf
+++ b/modules/tenant/cloudscanner_secrets.tf
@@ -11,8 +11,8 @@ locals {
 resource "azurerm_key_vault" "orgwide_key_vault" {
   count                     = local.cloudscanner_enabled ? 1 : 0
   name                      = local.key_vault_name
-  location                  = azurerm_resource_group.orgwide_resource_group.location
-  resource_group_name       = azurerm_resource_group.orgwide_resource_group.name
+  location                  = azurerm_resource_group.orgwide_resource_group[0].location
+  resource_group_name       = azurerm_resource_group.orgwide_resource_group[0].name
   tenant_id                 = data.azurerm_subscription.orchestrator.tenant_id
   sku_name                  = "standard"
   enable_rbac_authorization = true
@@ -45,6 +45,7 @@ resource "azurerm_role_assignment" "kv_secrets_scaler" {
 
 # Add organization-wide secrets to Key Vault
 resource "azurerm_key_vault_secret" "scanner_client_id" {
+  count        = local.cloudscanner_enabled ? 1 : 0
   name         = "upwind-client-id"
   value        = var.scanner_client_id
   key_vault_id = azurerm_key_vault.orgwide_key_vault[0].id
@@ -52,6 +53,7 @@ resource "azurerm_key_vault_secret" "scanner_client_id" {
 }
 
 resource "azurerm_key_vault_secret" "scanner_client_secret" {
+  count        = local.cloudscanner_enabled ? 1 : 0
   name         = "upwind-client-secret"
   value        = var.scanner_client_secret
   key_vault_id = azurerm_key_vault.orgwide_key_vault[0].id

--- a/modules/tenant/variables.tf
+++ b/modules/tenant/variables.tf
@@ -19,12 +19,14 @@ variable "upwind_client_secret" {
 variable "scanner_client_id" {
   description = "The client ID used for authentication with the Upwind CloudScanner Service."
   type        = string
+  default     = ""
 }
 
 variable "scanner_client_secret" {
   description = "The client secret for authentication with the Upwind CloudScanner Service."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "upwind_auth_endpoint" {


### PR DESCRIPTION
We want to allow TF runners to leave scanner credentials out and therefore skip all Cloudscanner related deployments as part of onboarding.
