### PR TITLE
chore(AG-3590): adding missing roles for service principal reading

### DIFF
--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -82,7 +82,11 @@ variable "azure_application_msgraph_roles" {
   description = "List of Microsoft Graph API roles that should be granted to the Azure AD application."
   type        = list(string)
   default = [
+    "User.Read.All",
+    "Group.Read.All",
+    "RoleManagement.Read.All",
     "Directory.Read.All",
+    "Application.Read.All",
     "Policy.Read.All",
     "UserAuthenticationMethod.Read.All",
   ]

--- a/modules/tenant/README.md
+++ b/modules/tenant/README.md
@@ -83,7 +83,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_azure_application_msgraph_roles"></a> [azure\_application\_msgraph\_roles](#input\_azure\_application\_msgraph\_roles) | List of Microsoft Graph API roles that should be granted to the Azure AD application. | `list(string)` | <pre>[<br/>  "Directory.Read.All",<br/>  "Policy.Read.All",<br/>  "UserAuthenticationMethod.Read.All"<br/>]</pre> | no |
+| <a name="input_azure_application_msgraph_roles"></a> [azure\_application\_msgraph\_roles](#input\_azure\_application\_msgraph\_roles) | List of Microsoft Graph API roles that should be granted to the Azure AD application. | `list(string)` | <pre>[<br/>  "User.Read.All",<br/>  "Group.Read.All",<br/>  "RoleManagement.Read.All",<br/>  "Directory.Read.All",<br/>  "Application.Read.All",<br/>  "Policy.Read.All",<br/>  "UserAuthenticationMethod.Read.All"<br/>]</pre> | no |
 | <a name="input_azure_application_name_prefix"></a> [azure\_application\_name\_prefix](#input\_azure\_application\_name\_prefix) | The prefix used for the name of the Azure AD application. | `string` | `"upwindsecurity"` | no |
 | <a name="input_azure_application_owners"></a> [azure\_application\_owners](#input\_azure\_application\_owners) | List of user IDs that will be set as owners of the Azure application. Each ID should be in the form of a GUID. If this list is left empty, the owner defaults to the authenticated principal. | `list(string)` | `[]` | no |
 | <a name="input_azure_cloudscanner_location"></a> [azure\_cloudscanner\_location](#input\_azure\_cloudscanner\_location) | The region where the org-wide resource group will be deployed. | `string` | `"westus"` | no |

--- a/modules/tenant/variables.tf
+++ b/modules/tenant/variables.tf
@@ -89,7 +89,11 @@ variable "azure_application_msgraph_roles" {
   description = "List of Microsoft Graph API roles that should be granted to the Azure AD application."
   type        = list(string)
   default = [
+    "User.Read.All",
+    "Group.Read.All",
+    "RoleManagement.Read.All",
     "Directory.Read.All",
+    "Application.Read.All",
     "Policy.Read.All",
     "UserAuthenticationMethod.Read.All",
   ]


### PR DESCRIPTION
Adding roles that were missing, were recently added to legacy TF module.
