### PR TITLE
fix(AG-0): add postconditions to HTTP data sources for error visibility

### DIFF
--- a/modules/subscription/auth.tf
+++ b/modules/subscription/auth.tf
@@ -37,5 +37,9 @@ data "http" "upwind_get_access_token_request" {
       condition     = var.upwind_client_id != null && var.upwind_client_secret != null
       error_message = "Invalid client credentials. Please verify your client ID and client secret."
     }
+    postcondition {
+      condition     = self.status_code == 200
+      error_message = "Failed to obtain access token (status ${self.status_code}). Response: ${self.response_body}."
+    }
   }
 }

--- a/modules/subscription/main.tf
+++ b/modules/subscription/main.tf
@@ -289,16 +289,10 @@ data "http" "upwind_get_cloud_credentials_request" {
       error_message = "Unable to obtain access token. Please verify your client ID and client secret. Response: ${data.http.upwind_get_access_token_request.response_body}."
     }
 
-    # The fix #35895 for issue #34310 is included in version 1.10.0 and later.
-    # Since version 1.10.0 was recently released and is not yet widely adopted,
-    # using postconditions could introduce or exacerbate errors. To prevent
-    # potential issues, we should avoid using postconditions until this version
-    # is more commonly utilized.
-    #
-    # postcondition {
-    #   condition     = contains([200], self.status_code)
-    #   error_message = "Error encountered with status code: ${self.status_code}. Response: ${self.response_body}."
-    # }
+    postcondition {
+      condition     = contains([200], self.status_code)
+      error_message = "Failed to get cloud credentials (status ${self.status_code}). Response: ${self.response_body}."
+    }
   }
 }
 
@@ -352,15 +346,9 @@ data "http" "upwind_create_cloud_credentials_request" {
       error_message = "Unable to obtain access token. Please verify your client ID and client secret. Response: ${data.http.upwind_get_access_token_request.response_body}."
     }
 
-    # The fix #35895 for issue #34310 is included in version 1.10.0 and later.
-    # Since version 1.10.0 was recently released and is not yet widely adopted,
-    # using postconditions could introduce or exacerbate errors. To prevent
-    # potential issues, we should avoid using postconditions until this version
-    # is more commonly utilized.
-    #
-    # postcondition {
-    #   condition     = contains([201, 204], self.status_code)
-    #   error_message = "Error encountered with status code: ${self.status_code}. Response: ${self.response_body}."
-    # }
+    postcondition {
+      condition     = contains([201, 204], self.status_code)
+      error_message = "Failed to create cloud credentials (status ${self.status_code}). Response: ${self.response_body}."
+    }
   }
 }

--- a/modules/tenant/auth.tf
+++ b/modules/tenant/auth.tf
@@ -39,5 +39,9 @@ data "http" "upwind_get_access_token_request" {
       condition     = var.upwind_client_id != null && var.upwind_client_secret != null
       error_message = "Invalid client credentials. Please verify your client ID and client secret."
     }
+    postcondition {
+      condition     = self.status_code == 200
+      error_message = "Failed to obtain access token from ${local.upwind_auth_endpoint} (status ${self.status_code}). Response: ${self.response_body}."
+    }
   }
 }

--- a/modules/tenant/main.tf
+++ b/modules/tenant/main.tf
@@ -286,6 +286,10 @@ data "http" "upwind_get_organizational_credentials_request" {
       condition     = local.upwind_access_token != null
       error_message = "Unable to obtain access token. Please verify your client ID and client secret. Response: ${data.http.upwind_get_access_token_request.response_body}."
     }
+    postcondition {
+      condition     = self.status_code == 200
+      error_message = "Failed to get organizational credentials (status ${self.status_code}). Response: ${self.response_body}."
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `postcondition` blocks to all HTTP data sources across both tenant and subscription modules so API errors are surfaced directly in Terraform output
- Uncomments previously disabled postconditions in the subscription module (were blocked by a TF bug fixed in 1.10.0, released late 2024)
- No more digging through backend logs to figure out what went wrong during onboarding

## Changes
| Module | Resource | Postcondition |
|--------|----------|---------------|
| tenant | `upwind_get_access_token_request` | status 200 |
| tenant | `upwind_get_organizational_credentials_request` | status 200 |
| tenant | `upwind_create_organizational_credentials_request` | _(already existed)_ |
| subscription | `upwind_get_access_token_request` | status 200 |
| subscription | `upwind_get_cloud_credentials_request` | status 200 (uncommented) |
| subscription | `upwind_create_cloud_credentials_request` | status 201/204 (uncommented) |

## Test plan
- [x] `terraform validate` passes for both modules
- [x] All pre-commit hooks pass (fmt, tflint, trivy, docs)
- [ ] Verify error messages render correctly on a failed onboarding attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)