### PR TITLE
feat(AG-8730): allow credential overwrite on Azure tenant re-onboard

### DIFF
--- a/modules/tenant/README.md
+++ b/modules/tenant/README.md
@@ -20,10 +20,10 @@ seamlessly connect their entire tenant for comprehensive monitoring and security
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.6.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.52.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.8.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.70.0 |
 | <a name="provider_http"></a> [http](#provider\_http) | 3.5.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.13.1 |
 
 ## Modules

--- a/modules/tenant/main.tf
+++ b/modules/tenant/main.tf
@@ -10,10 +10,11 @@ locals {
     mg_id : "/providers/Microsoft.Management/managementGroups/${mg_id}"
   ]
 
-  # Create a map of existing organizational credentials
+  # Map tenant_id -> stored client_id from Upwind. Falls back to "" when the API
+  # response omits clientId (older monolith), which keeps presence-only behavior.
   organizational_credentials = {
     for cc in jsondecode(data.http.upwind_get_organizational_credentials_request.response_body) :
-    lower(cc.azureOrganizationId) => true
+    lower(cc.azureOrganizationId) => try(cc.clientId, "")
   }
 
   # Tenant ID to onboard - single tenant approach
@@ -21,8 +22,16 @@ locals {
   # Otherwise, derive it from the orchestrator subscription's tenant
   tenant_id = var.azure_tenant_id != "" ? var.azure_tenant_id : data.azurerm_subscription.orchestrator.tenant_id
 
-  # Determine if this tenant is pending onboarding (does not have existing credentials)
-  pending_tenant = lookup(local.organizational_credentials, local.tenant_id, false) == false ? local.tenant_id : null
+  # Stale-credential detection. A tenant is "pending" (POST should fire) when:
+  #   - it isn't onboarded yet (lookup returns null), OR
+  #   - it's onboarded and the stored client_id differs from the local one.
+  # When the API doesn't return clientId (older monolith), stored_client_id is "" and
+  # we fall back to presence-only behavior to avoid false positives.
+  stored_client_id   = lookup(local.organizational_credentials, local.tenant_id, null)
+  tenant_missing     = local.stored_client_id == null
+  tenant_stale       = local.stored_client_id != null && local.stored_client_id != "" && lower(local.stored_client_id) != lower(local.application_client_id)
+  pending_tenant     = (local.tenant_missing || local.tenant_stale) ? local.tenant_id : null
+  overwrite_required = local.tenant_stale
 
   # Determine effective scopes for service principal role assignments
   # Priority logic:
@@ -319,6 +328,7 @@ data "http" "upwind_create_organizational_credentials_request" {
   request_body = jsonencode(
     {
       "azure_organization_id" = local.pending_tenant
+      "allow_overwrite"       = local.overwrite_required
       "create_credentials_request" = {
         "provider" = {
           "name"            = "azure",


### PR DESCRIPTION
## Summary

Consumes the new `clientId` field on `GET /organizational-credentials/azure` and the new `allow_overwrite` flag on `POST /organizational-accounts/azure/onboard` (both shipped in [monolith#4561](https://github.com/upwindsecurity/monolith/pull/4561)) to fix the destroy + apply re-onboarding loop.

After a customer destroys their Azure AD app via `terraform destroy`, the next `terraform apply` previously skipped the POST because Upwind still showed the tenant as onboarded — leaving them stuck with stale credentials and requiring manual cleanup (e.g. IOAUSA). This change detects the staleness via a `client_id` diff and triggers an explicit overwrite.

**⚠️ Do not merge or release until the monolith PR has rolled out across all regions** — the new module sends `allow_overwrite` and reads `clientId`, both no-ops against an unupgraded monolith but the staleness detection only works once the GET response includes the field.

## Flow

```
                       ┌──────────────────────────────────────────┐
                       │  customer runs: terraform apply          │
                       └────────────────────┬─────────────────────┘
                                            │
                                            ▼
              ┌──────────────────────────────────────────────────────┐
              │  TF tenant module (this PR)                          │
              │                                                      │
              │  GET /organizational-credentials/azure  ────┐        │
              │                                             │        │
              │  ◄────  [{ azureOrganizationId, clientId }] ┘        │
              │                                                      │
              │  build map: tenant_id → stored_client_id             │
              │                                                      │
              │       ┌────────────────────────────────────┐         │
              │       │ stored_client_id == null ?         │         │
              │       │   → tenant_missing                 │         │
              │       │ stored != local.application_id ?   │         │
              │       │   → tenant_stale                   │         │
              │       │ otherwise                          │         │
              │       │   → no-op (skip POST)              │         │
              │       └────────────────────────────────────┘         │
              └──────────────────────┬───────────────────────────────┘
                                     │
                  ┌──────────────────┼─────────────────────────┐
                  │                  │                         │
              missing              stale                    no-op
                  │                  │                         │
                  ▼                  ▼                         ▼
   POST .../azure/onboard      POST .../azure/onboard       (done)
   {                           {
     allow_overwrite: false,     allow_overwrite: TRUE,
     spec: { client_id, ... }    spec: { new client_id, ... }
   }                           }
```

## Backwards compatibility

- **New module × old monolith** — the GET response omits `clientId`. `try(cc.clientId, "")` returns `""`, `tenant_stale` evaluates to `false`, and the module falls back to today's presence-only behavior. `allow_overwrite` is ignored by older monolith versions thanks to `@JsonIgnoreProperties(ignoreUnknown=true)`. Net result: no regression for users running the new module against older monolith deployments.
- **Existing-app path** (`var.azure_application_client_id != null`) — `local.application_client_id` resolves to the existing app id, so the diff still works correctly when customers BYO their own Azure AD app.
- **Destroy path** (`var.create_organizational_credentials = false`) — gating remains `local.pending_tenant != null && var.create_organizational_credentials`, so destroy still skips the POST.

## Test plan

- [x] `terraform fmt -check` clean
- [x] `terraform validate` clean
- [x] `tflint` clean
- [x] `make test-module MODULE=tenant` (init + validate + fmt + tflint + trivy) — exit 0
- [ ] Smoke test against dev: simulate a stale-credential state, run `terraform apply`, confirm the POST is sent with `allow_overwrite=true` and the credentials are replaced
- [ ] No-op smoke test: run `terraform apply` twice in a row against the same tenant, confirm the second run does not re-POST

## Notes

- README provider-version drift is from the pre-commit `terraform-docs` hook regenerating against currently-installed providers. Unrelated to AG-8730 but unavoidable through the standard commit flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
