### PR TITLE
fix(UP-2038): include scope in CloudScannerAppServiceScmRole name

### DIFF
--- a/modules/tenant/cloudscanner_iam.tf
+++ b/modules/tenant/cloudscanner_iam.tf
@@ -155,7 +155,7 @@ resource "azurerm_role_assignment" "storage_file_reader" {
 resource "azurerm_role_definition" "app_service_scm_bearer_reader" {
   for_each = (local.cloudscanner_enabled && !var.disable_function_scanning) ? toset(local.cloudscanner_scopes) : []
 
-  name        = "CloudScannerAppServiceScmRole-${local.resource_suffix}"
+  name        = "CloudScannerAppServiceScmRole-${local.resource_suffix}-${split("/", each.value)[length(split("/", each.value)) - 1]}"
   description = "Role for CloudScanner workers to read App Service metadata and access SCM with bearer authentication in this scope"
   scope       = each.value
 


### PR DESCRIPTION
## Summary

Fixes [UP-2038](https://upwindsecurity.atlassian.net/browse/UP-2038).

When onboarding multiple management groups, `azurerm_role_definition.app_service_scm_bearer_reader` fans out over `local.cloudscanner_scopes` via `for_each`, but the role name was static (`CloudScannerAppServiceScmRole-${local.resource_suffix}`). Azure custom role definition names must be unique per tenant, so multiple scopes produced colliding names and the apply failed.

## Change

Append the scope's last path segment to the role name, matching the existing `CloudScannerTargetRole` pattern (cloudscanner_iam.tf:268):

```hcl
name = "CloudScannerAppServiceScmRole-${local.resource_suffix}-${split("/", each.value)[length(split("/", each.value)) - 1]}"
```

## Testing

- `terraform validate` passes
- pre-commit hooks pass (fmt, tflint, trivy, terraform-docs, commitizen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UP-2038]: https://upwindsecurity.atlassian.net/browse/UP-2038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ