### PR TITLE
feat(UP-1777): saas role parity + re-add Web/sites/host/listkeys to custom role

### DIFF
--- a/modules/tenant/README.md
+++ b/modules/tenant/README.md
@@ -21,11 +21,11 @@ seamlessly connect their entire tenant for comprehensive monitoring and security
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.8.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.77.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | 3.6.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >= 2.53 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.42 |
+| <a name="provider_http"></a> [http](#provider\_http) | >= 3.4 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.8 |
 
 ## Modules
 
@@ -59,7 +59,10 @@ No modules.
 | [azurerm_role_assignment.kv_secrets_scaler](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.kv_secrets_worker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.saas_fetcher](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.saas_fetcher_custom_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.saas_snapshot](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.saas_snapshot_target_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.saas_snapshot_worker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.storage_file_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.storage_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.target_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -68,6 +71,8 @@ No modules.
 | [azurerm_role_definition.cloudscanner_worker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.custom](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.deployer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.saas_fetcher_custom_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.saas_snapshot_target_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.target_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_user_assigned_identity.key_vault_access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [azurerm_user_assigned_identity.scaler_user_assigned_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
@@ -79,6 +84,7 @@ No modules.
 | [time_sleep.cloudscanner_scaler_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.cloudscanner_worker_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.deployer_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [time_sleep.saas_snapshot_target_role_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.target_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/application_published_app_ids) | data source |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
@@ -102,7 +108,7 @@ No modules.
 | <a name="input_azure_application_service_principal_object_id"></a> [azure\_application\_service\_principal\_object\_id](#input\_azure\_application\_service\_principal\_object\_id) | The service principal object ID of the existing Azure AD application. Optional, if provided the module will skip looking up the service principal object ID. Useful if graph permissions cannot be configured for the TF runner App Registration. Required when onboarding via a multi-tenant application registered in a different tenant: the app registration is not visible in the tenant being onboarded, so the data-source lookup of the application would fail at plan time — supplying the SP object ID directly bypasses that lookup. Should be managed externally (e.g., Azure Portal, CLI, or separate automation). | `string` | `null` | no |
 | <a name="input_azure_cloudscanner_location"></a> [azure\_cloudscanner\_location](#input\_azure\_cloudscanner\_location) | The region where the org-wide resource group will be deployed. | `string` | `"westus"` | no |
 | <a name="input_azure_custom_role_name_prefix"></a> [azure\_custom\_role\_name\_prefix](#input\_azure\_custom\_role\_name\_prefix) | The prefix used for the name of the Azure role definition. | `string` | `"upwindsecurity"` | no |
-| <a name="input_azure_custom_role_permissions"></a> [azure\_custom\_role\_permissions](#input\_azure\_custom\_role\_permissions) | List of custom permissions that should be granted to the service principal through a custom role. | `list(string)` | <pre>[<br/>  "Microsoft.Web/sites/config/list/Action"<br/>]</pre> | no |
+| <a name="input_azure_custom_role_permissions"></a> [azure\_custom\_role\_permissions](#input\_azure\_custom\_role\_permissions) | List of custom permissions that should be granted to the service principal through a custom role. | `list(string)` | <pre>[<br/>  "Microsoft.Web/sites/host/listkeys/action",<br/>  "Microsoft.Web/sites/config/list/Action"<br/>]</pre> | no |
 | <a name="input_azure_management_group_ids"></a> [azure\_management\_group\_ids](#input\_azure\_management\_group\_ids) | List of management group names (not full resource IDs) to grant read access to. For example, use 'upwindsecurity-sandbox' instead of '/providers/Microsoft.Management/managementGroups/upwindsecurity-sandbox'. Can be combined with subscription include/exclude filters to further refine the scope. | `list(string)` | `[]` | no |
 | <a name="input_azure_orchestrator_subscription_id"></a> [azure\_orchestrator\_subscription\_id](#input\_azure\_orchestrator\_subscription\_id) | The subscription ID where the Upwind components will be deployed. The module will assume deployment permissions in this subscription via a custom role definition. | `string` | n/a | yes |
 | <a name="input_azure_role_definition_wait_time"></a> [azure\_role\_definition\_wait\_time](#input\_azure\_role\_definition\_wait\_time) | The duration of time to wait after Azure role definitions are created to ensure full propagation and prevent timing issues in dependent resources. | `string` | `"10s"` | no |
@@ -114,7 +120,7 @@ No modules.
 | <a name="input_cloudscanner_include_subscriptions"></a> [cloudscanner\_include\_subscriptions](#input\_cloudscanner\_include\_subscriptions) | Optional list of subscription IDs to include for cloudscanner managed identity role assignments. If provided, cloudscanner roles will only be assigned to these subscriptions. Mutually exclusive with cloudscanner\_exclude\_subscriptions. Can be combined with azure\_management\_group\_ids or azure\_tenant\_id. This will enable us to scan resources in these subscriptions. Cloudscanner scope should be a subset of cloudapi scope. | `list(string)` | `[]` | no |
 | <a name="input_create_organizational_credentials"></a> [create\_organizational\_credentials](#input\_create\_organizational\_credentials) | Set to false to skip sending organizational credentials to Upwind. The default value for this variable should be set to true for onboarding deployments using 'terraform init && terraform apply' and set to false when offboarding using 'terraform destroy'. It is essential that it is reset appropriately for subsequent deploy / destroy attempts. | `bool` | `true` | no |
 | <a name="input_disable_function_scanning"></a> [disable\_function\_scanning](#input\_disable\_function\_scanning) | If set to true will disable Storage Blob Data Reader role assignment for upwind-cs-vmss-identity | `bool` | `false` | no |
-| <a name="input_fetcher_app_client_id"></a> [fetcher\_app\_client\_id](#input\_fetcher\_app\_client\_id) | SaaS mode: client ID of Upwind's multi-tenant Fetcher app registration. Its service principal is materialized in the customer tenant and granted Reader at the tenant-root management group. Required when saas\_enabled is true, unless fetcher\_app\_service\_principal\_object\_id is provided. | `string` | `""` | no |
+| <a name="input_fetcher_app_client_id"></a> [fetcher\_app\_client\_id](#input\_fetcher\_app\_client\_id) | SaaS mode: client ID of Upwind's multi-tenant Fetcher app registration. Its service principal is materialized in the customer tenant and granted, at the tenant-root management group, the outpost app-registration role set: the built-in read roles (var.azure\_roles) + a custom role (var.azure\_custom\_role\_permissions). Required when saas\_enabled is true, unless fetcher\_app\_service\_principal\_object\_id is provided. | `string` | `""` | no |
 | <a name="input_fetcher_app_service_principal_object_id"></a> [fetcher\_app\_service\_principal\_object\_id](#input\_fetcher\_app\_service\_principal\_object\_id) | SaaS mode (optional): object ID of an existing service principal for Upwind's Fetcher app registration in the customer tenant. Provide this when the SP has already been created out-of-band (e.g. via admin consent / `az ad sp create`) and the Terraform runner lacks Microsoft Graph permissions to create it. When set, the module skips creating the service principal and assigns roles to this object ID directly; fetcher\_app\_client\_id is then not required. | `string` | `""` | no |
 | <a name="input_function_storage_accounts"></a> [function\_storage\_accounts](#input\_function\_storage\_accounts) | Optional list of storage account resource IDs used by Function Apps. If provided, Storage Blob Data Reader role will only be assigned to these specific storage accounts instead of all resources in scope. Use the list-function-storage-accounts.sh script to discover these. Example: ["/subscriptions/{sub-id}/resourceGroups/{rg}/providers/Microsoft.Storage/storageAccounts/{name}"] | `list(string)` | `[]` | no |
 | <a name="input_key_vault_deny_traffic"></a> [key\_vault\_deny\_traffic](#input\_key\_vault\_deny\_traffic) | Whether to deny traffic to the Key Vault using network ACLs. When true, only trusted Azure services and allowed IPs can access the vault. | `bool` | `false` | no |
@@ -126,7 +132,7 @@ No modules.
 | <a name="input_scanner_client_id"></a> [scanner\_client\_id](#input\_scanner\_client\_id) | The client ID used for authentication with the Upwind CloudScanner Service. | `string` | `""` | no |
 | <a name="input_scanner_client_secret"></a> [scanner\_client\_secret](#input\_scanner\_client\_secret) | The client secret for authentication with the Upwind CloudScanner Service. | `string` | `""` | no |
 | <a name="input_skip_app_service_provider_registration"></a> [skip\_app\_service\_provider\_registration](#input\_skip\_app\_service\_provider\_registration) | DEPRECATED: We have removed the need for this variable. Set to true to skip the Microsoft.App provider registration, recommended if running on Windows. If resource\_providers\_to\_register is set to ["Microsoft.App"] on the azurerm provider, this can safely be set to true. | `bool` | `false` | no |
-| <a name="input_snapshot_app_client_id"></a> [snapshot\_app\_client\_id](#input\_snapshot\_app\_client\_id) | SaaS mode: client ID of Upwind's multi-tenant Snapshot app registration. Its service principal is materialized in the customer tenant and granted Reader + Disk Snapshot Contributor + Data Operator for Managed Disks at the tenant-root management group. Required when saas\_enabled is true, unless snapshot\_app\_service\_principal\_object\_id is provided. | `string` | `""` | no |
+| <a name="input_snapshot_app_client_id"></a> [snapshot\_app\_client\_id](#input\_snapshot\_app\_client\_id) | SaaS mode: client ID of Upwind's multi-tenant Snapshot app registration. Its service principal is materialized in the customer tenant and granted, at the tenant-root management group, the outpost worker role set: Reader + Disk Snapshot Contributor + Data Operator for Managed Disks + a CloudScannerTargetRole custom role + Storage Blob/File data-plane readers. Required when saas\_enabled is true, unless snapshot\_app\_service\_principal\_object\_id is provided. | `string` | `""` | no |
 | <a name="input_snapshot_app_service_principal_object_id"></a> [snapshot\_app\_service\_principal\_object\_id](#input\_snapshot\_app\_service\_principal\_object\_id) | SaaS mode (optional): object ID of an existing service principal for Upwind's Snapshot app registration in the customer tenant. Provide this when the SP has already been created out-of-band (e.g. via admin consent / `az ad sp create`) and the Terraform runner lacks Microsoft Graph permissions to create it. When set, the module skips creating the service principal and assigns roles to this object ID directly; snapshot\_app\_client\_id is then not required. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources. | `map(string)` | `{}` | no |
 | <a name="input_upwind_auth_endpoint"></a> [upwind\_auth\_endpoint](#input\_upwind\_auth\_endpoint) | The Authentication API endpoint. | `string` | `"https://auth.upwind.io"` | no |
@@ -134,7 +140,7 @@ No modules.
 | <a name="input_upwind_client_secret"></a> [upwind\_client\_secret](#input\_upwind\_client\_secret) | The client secret for authentication with the Upwind Authorization Service. Required for self-hosted onboarding; not used when saas\_enabled is true. | `string` | `""` | no |
 | <a name="input_upwind_integration_endpoint"></a> [upwind\_integration\_endpoint](#input\_upwind\_integration\_endpoint) | The Integration API endpoint. | `string` | `"https://integration.upwind.io"` | no |
 | <a name="input_upwind_organization_id"></a> [upwind\_organization\_id](#input\_upwind\_organization\_id) | The identifier of the Upwind organization to integrate with. | `string` | n/a | yes |
-| <a name="input_upwind_region"></a> [upwind\_region](#input\_upwind\_region) | The region where the Upwind components will be deployed. Must be 'us', 'eu' or 'me' | `string` | `"us"` | no |
+| <a name="input_upwind_region"></a> [upwind\_region](#input\_upwind\_region) | The region where the Upwind components will be deployed. Must be 'us', 'eu', 'ap' or 'me' | `string` | `"us"` | no |
 
 ## Outputs
 

--- a/modules/tenant/cloudscanner_iam.tf
+++ b/modules/tenant/cloudscanner_iam.tf
@@ -3,6 +3,24 @@
 locals {
   resource_suffix = format("%s%s", var.upwind_organization_id, var.resource_suffix)
 
+  # Actions granted by CloudScannerTargetRole: target-disk read + begin-access +
+  # ACR pull. Shared between the self-hosted (outpost) worker identity and the
+  # SaaS Snapshot SP (see saas.tf) so the two paths never drift - mirrors
+  # targetRoleActions in the serverless shared-role-config.jsonc.
+  cloudscanner_target_role_actions = [
+    "Microsoft.Compute/virtualMachines/instanceView/read",
+    "Microsoft.Compute/virtualMachines/read",
+    "Microsoft.Compute/virtualMachineScaleSets/read",
+    "Microsoft.Compute/virtualMachineScaleSets/instanceView/read",
+    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
+    "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/instanceView/read",
+    "Microsoft.Compute/disks/read",
+    "Microsoft.Compute/diskEncryptionSets/read",
+    "Microsoft.Compute/disks/beginGetAccess/action",
+    "Microsoft.ContainerRegistry/registries/pull/read",
+    "Microsoft.Web/sites/config/list/action"
+  ]
+
   # Determine cloudscanner role assignment scopes based on include/exclude subscription parameters
   # Priority logic:
   # 1. If include list is provided: use only those subscriptions (overrides management groups)
@@ -269,19 +287,7 @@ resource "azurerm_role_definition" "target_role" {
   description = "Role for CloudScanner workers to snapshot virtual machines and pull acr images in this scope"
   scope       = each.value
   permissions {
-    actions = [
-      "Microsoft.Compute/virtualMachines/instanceView/read",
-      "Microsoft.Compute/virtualMachines/read",
-      "Microsoft.Compute/virtualMachineScaleSets/read",
-      "Microsoft.Compute/virtualMachineScaleSets/instanceView/read",
-      "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/read",
-      "Microsoft.Compute/virtualMachineScaleSets/virtualMachines/instanceView/read",
-      "Microsoft.Compute/disks/read",
-      "Microsoft.Compute/diskEncryptionSets/read",
-      "Microsoft.Compute/disks/beginGetAccess/action",
-      "Microsoft.ContainerRegistry/registries/pull/read",
-      "Microsoft.Web/sites/config/list/action"
-    ]
+    actions = local.cloudscanner_target_role_actions
   }
 }
 

--- a/modules/tenant/saas.tf
+++ b/modules/tenant/saas.tf
@@ -9,13 +9,29 @@
 # Key Vault, managed identities, custom roles, credential submission) are gated
 # off when saas_enabled is true.
 #
+# The role sets mirror the self-hosted (outpost) principals so the two paths stay
+# in lock-step - the same source of truth (var.azure_roles / var.azure_custom_role_permissions)
+# feeds both. Application translation (from the outpost path / mg-roles.bicep):
+#   service principal (app registration) -> Fetcher SP  (read-level inventory)
+#   worker identity                      -> Snapshot SP (snapshotting)
+#
 # The worker creates each snapshot in the target disk's own subscription/RG, so
 # the Snapshot SP is granted tenant-wide write for first delivery. Narrowing the
 # write grant to a least-privilege boundary is a tracked follow-up.
 
 locals {
-  # Built-in roles for the Snapshot SP (snapshot CRUD + cross-subscription disk read).
+  # --- Snapshot SP (mirrors the outpost worker identity) ---
+
+  # SaaS-specific built-in roles: snapshot CRUD + cross-subscription disk read.
+  # The custom CloudScannerTargetRole is granted separately below.
   saas_snapshot_roles = ["Reader", "Disk Snapshot Contributor", "Data Operator for Managed Disks"]
+
+  # Worker data-plane read roles - mirrors the outpost storage_reader /
+  # storage_file_reader assignments (bicep workerBuiltinRoles). Assigned at MG
+  # scope so the Snapshot SP can read across every subscription in the tenant.
+  saas_snapshot_worker_roles = ["Storage Blob Data Reader", "Storage File Data Privileged Reader"]
+
+  # --- SP materialization ---
 
   # Create the SP only when an existing object ID was not supplied. When the
   # customer pre-creates the SP out-of-band (e.g. admin consent), they pass its
@@ -28,14 +44,36 @@ locals {
   saas_snapshot_sp_object_id = var.snapshot_app_service_principal_object_id != "" ? var.snapshot_app_service_principal_object_id : one(azuread_service_principal.saas_snapshot[*].object_id)
   saas_fetcher_sp_object_id  = var.fetcher_app_service_principal_object_id != "" ? var.fetcher_app_service_principal_object_id : one(azuread_service_principal.saas_fetcher[*].object_id)
 
-  # Snapshot role assignments keyed by "scope|role" across the MG scope(s).
+  # --- Assignment maps (keyed by "scope|role" across the MG scope(s)) ---
+
+  # Snapshot SP built-in roles.
   saas_snapshot_role_assignments = var.saas_enabled ? {
     for pair in setproduct(local.normalized_management_group_ids, local.saas_snapshot_roles) :
     "${pair[0]}|${pair[1]}" => { scope = pair[0], role = pair[1] }
   } : {}
 
-  # Fetcher gets Reader at each MG scope.
-  saas_fetcher_scopes = var.saas_enabled ? toset(local.normalized_management_group_ids) : []
+  # Snapshot SP worker data-plane roles.
+  saas_snapshot_worker_role_assignments = var.saas_enabled ? {
+    for pair in setproduct(local.normalized_management_group_ids, local.saas_snapshot_worker_roles) :
+    "${pair[0]}|${pair[1]}" => { scope = pair[0], role = pair[1] }
+  } : {}
+
+  # Snapshot SP CloudScannerTargetRole scopes (target-disk read + begin-access +
+  # ACR pull - identical actions to the outpost worker's target role).
+  saas_target_role_scopes = var.saas_enabled ? toset(local.normalized_management_group_ids) : []
+
+  # --- Fetcher SP (mirrors the outpost app-registration SP) ---
+
+  # Fetcher SP built-in read roles (var.azure_roles - same list the outpost app
+  # registration gets; bicep builtinRoles).
+  saas_fetcher_role_assignments = var.saas_enabled ? {
+    for pair in setproduct(local.normalized_management_group_ids, var.azure_roles) :
+    "${pair[0]}|${pair[1]}" => { scope = pair[0], role = pair[1] }
+  } : {}
+
+  # Fetcher SP custom-role scopes (var.azure_custom_role_permissions - same custom
+  # role the outpost app registration gets; bicep customRole).
+  saas_fetcher_custom_role_scopes = (var.saas_enabled && length(var.azure_custom_role_permissions) > 0) ? toset(local.normalized_management_group_ids) : []
 }
 
 # Materialize the consented service principal for Upwind's Snapshot app reg
@@ -68,6 +106,8 @@ resource "azuread_service_principal" "saas_fetcher" {
   }
 }
 
+# region Snapshot SP roles
+
 # Snapshot SP -> Reader + Disk Snapshot Contributor + Data Operator at MG scope.
 resource "azurerm_role_assignment" "saas_snapshot" {
   for_each = local.saas_snapshot_role_assignments
@@ -77,13 +117,80 @@ resource "azurerm_role_assignment" "saas_snapshot" {
   scope                = each.value.scope
 }
 
-# Fetcher SP -> Reader at MG scope.
+# Snapshot SP -> Storage Blob / File data-plane readers at MG scope
+# (mirrors the outpost worker's storage_reader / storage_file_reader).
+resource "azurerm_role_assignment" "saas_snapshot_worker" {
+  for_each = local.saas_snapshot_worker_role_assignments
+
+  principal_id         = local.saas_snapshot_sp_object_id
+  role_definition_name = each.value.role
+  scope                = each.value.scope
+}
+
+# CloudScannerTargetRole custom role definition per MG scope (identical actions
+# to the outpost worker's target role - local.cloudscanner_target_role_actions).
+resource "azurerm_role_definition" "saas_snapshot_target_role" {
+  for_each    = local.saas_target_role_scopes
+  name        = "CloudScannerTargetRole-${local.resource_suffix}-${split("/", each.value)[length(split("/", each.value)) - 1]}"
+  description = "Role for CloudScanner workers to snapshot virtual machines and pull acr images in this scope"
+  scope       = each.value
+  permissions {
+    actions = local.cloudscanner_target_role_actions
+  }
+}
+
+# Wait for the target role definitions to propagate before assigning them.
+resource "time_sleep" "saas_snapshot_target_role_wait" {
+  count           = var.saas_enabled ? 1 : 0
+  depends_on      = [azurerm_role_definition.saas_snapshot_target_role]
+  create_duration = var.azure_role_definition_wait_time
+}
+
+# Snapshot SP -> CloudScannerTargetRole at each MG scope.
+resource "azurerm_role_assignment" "saas_snapshot_target_role" {
+  for_each = azurerm_role_definition.saas_snapshot_target_role
+
+  role_definition_id = each.value.role_definition_resource_id
+  principal_id       = local.saas_snapshot_sp_object_id
+  scope              = each.value.scope
+  depends_on         = [time_sleep.saas_snapshot_target_role_wait[0]]
+}
+
+# endregion
+
+# region Fetcher SP roles
+
+# Fetcher SP -> built-in read roles (var.azure_roles) at each MG scope.
 resource "azurerm_role_assignment" "saas_fetcher" {
-  for_each = local.saas_fetcher_scopes
+  for_each = local.saas_fetcher_role_assignments
 
   principal_id         = local.saas_fetcher_sp_object_id
-  role_definition_name = "Reader"
-  scope                = each.value
+  role_definition_name = each.value.role
+  scope                = each.value.scope
 }
+
+# Fetcher custom role definition per MG scope (var.azure_custom_role_permissions -
+# same actions the outpost app registration's custom role gets).
+resource "azurerm_role_definition" "saas_fetcher_custom_role" {
+  for_each    = local.saas_fetcher_custom_role_scopes
+  name        = "UpwindCustomRole-${local.resource_suffix}-${split("/", each.value)[length(split("/", each.value)) - 1]}"
+  description = "Custom role for the Upwind CloudScanner Fetcher service principal in this scope"
+  scope       = each.value
+  permissions {
+    actions     = var.azure_custom_role_permissions
+    not_actions = []
+  }
+}
+
+# Fetcher SP -> custom role at each MG scope.
+resource "azurerm_role_assignment" "saas_fetcher_custom_role" {
+  for_each = azurerm_role_definition.saas_fetcher_custom_role
+
+  role_definition_id = each.value.role_definition_resource_id
+  principal_id       = local.saas_fetcher_sp_object_id
+  scope              = each.value.scope
+}
+
+# endregion
 
 # endregion saas

--- a/modules/tenant/variables.tf
+++ b/modules/tenant/variables.tf
@@ -183,6 +183,7 @@ variable "azure_custom_role_permissions" {
   description = "List of custom permissions that should be granted to the service principal through a custom role."
   type        = list(string)
   default = [
+    "Microsoft.Web/sites/host/listkeys/action",
     "Microsoft.Web/sites/config/list/Action",
   ]
 }
@@ -313,7 +314,7 @@ variable "saas_enabled" {
 }
 
 variable "snapshot_app_client_id" {
-  description = "SaaS mode: client ID of Upwind's multi-tenant Snapshot app registration. Its service principal is materialized in the customer tenant and granted Reader + Disk Snapshot Contributor + Data Operator for Managed Disks at the tenant-root management group. Required when saas_enabled is true, unless snapshot_app_service_principal_object_id is provided."
+  description = "SaaS mode: client ID of Upwind's multi-tenant Snapshot app registration. Its service principal is materialized in the customer tenant and granted, at the tenant-root management group, the outpost worker role set: Reader + Disk Snapshot Contributor + Data Operator for Managed Disks + a CloudScannerTargetRole custom role + Storage Blob/File data-plane readers. Required when saas_enabled is true, unless snapshot_app_service_principal_object_id is provided."
   type        = string
   default     = ""
 
@@ -324,7 +325,7 @@ variable "snapshot_app_client_id" {
 }
 
 variable "fetcher_app_client_id" {
-  description = "SaaS mode: client ID of Upwind's multi-tenant Fetcher app registration. Its service principal is materialized in the customer tenant and granted Reader at the tenant-root management group. Required when saas_enabled is true, unless fetcher_app_service_principal_object_id is provided."
+  description = "SaaS mode: client ID of Upwind's multi-tenant Fetcher app registration. Its service principal is materialized in the customer tenant and granted, at the tenant-root management group, the outpost app-registration role set: the built-in read roles (var.azure_roles) + a custom role (var.azure_custom_role_permissions). Required when saas_enabled is true, unless fetcher_app_service_principal_object_id is provided."
   type        = string
   default     = ""
 


### PR DESCRIPTION
## Match Terraform SaaS role sets to ARM; re-add `Web/sites/host/listkeys` to the custom role

### Summary
Brings the Terraform `tenant` module's SaaS (provider-hosted) role assignments to parity with the ARM `saas-mg-roles.bicep` changes. In SaaS mode the Snapshot and Fetcher service principals now receive the same role sets as the self-hosted (outpost) worker identity and app-registration SP respectively, sourced from the same Terraform variables so the two paths can't drift. Also re-adds `Microsoft.Web/sites/host/listkeys/action` to the custom role to realign Terraform with ARM.

### Application translation (outpost → SaaS)
- outpost **app-registration SP** → **Fetcher SP** (read-level inventory)
- outpost **worker identity** → **Snapshot SP** (snapshotting)

### Changes

**`modules/tenant/saas.tf`** — SaaS role parity, all gated on `var.saas_enabled`:

| Principal | Roles | Status |
|---|---|---|
| **Snapshot SP** | Reader + Disk Snapshot Contributor + Data Operator for Managed Disks | existing |
| | CloudScannerTargetRole (shared `local.cloudscanner_target_role_actions`) | added |
| | Storage Blob Data Reader + Storage File Data Privileged Reader (`saas_snapshot_worker`) | **new** — mirrors outpost `storage_reader`/`storage_file_reader` (bicep `workerBuiltinRoles`) |
| **Fetcher SP** | `var.azure_roles` — Reader, Security Reader, Key Vault Reader, Cosmos DB Account Reader, Backup Reader, Log Analytics Reader, Cognitive Services Data Reader | **new** — replaces the single `Reader` (Reader is `azure_roles[0]`, no loss) |
| | custom role from `var.azure_custom_role_permissions` | **new** — mirrors outpost `azurerm_role_definition.custom` (bicep `customRole`) |

**`modules/tenant/cloudscanner_iam.tf`** — extracted the CloudScanner target-role action list into a shared local `cloudscanner_target_role_actions`; the outpost `target_role` now references it. Behavior-identical (same actions, same order) — single source of truth prevents future outpost/SaaS drift.

**`modules/tenant/variables.tf`**
- Re-added `Microsoft.Web/sites/host/listkeys/action` to the `azure_custom_role_permissions` default, reverting the AG-3913 "YAGNI" removal to realign with ARM. **Note:** this changes the existing self-hosted/outpost custom role as well as SaaS.
- Updated `snapshot_app_client_id` / `fetcher_app_client_id` descriptions to the full role sets.

**`modules/tenant/README.md`** — regenerated via terraform-docs (new resources + updated variable default).

### Backward compatibility / outpost impact
- All new `saas.tf` resources are gated on `var.saas_enabled`; with it `false` (the outpost default) every SaaS local resolves empty → **zero** SaaS resources planned.
- The `cloudscanner_iam.tf` refactor is behavior-preserving for the outpost path.
- **One intentional outpost change:** re-adding `host/listkeys/action` adds one permission to the existing self-hosted custom role. This is a deliberate reconciliation with ARM (approved), not incidental — flagged here for reviewers.

### Testing
- `terraform fmt` — clean
- `terraform validate` (tenant module) — **Success**
- terraform-docs regenerated, no manual drift

A live `terraform plan`/apply needs a real tenant + the Snapshot/Fetcher SP object IDs (the runtime-acceptance gap tracked on the ARM side); static validation is the appropriate level until those exist.

### Related
- ARM counterpart: `upwind-azure-serverless` `saas-mg-roles.bicep` parity change (merge/release first).
- Reverts: `AG-3913` (#25) removal of `Microsoft.Web/sites/host/listkeys/action`.