### PR TITLE
feat(UP-3155): support private networking key vault for tenant onboarding

### DIFF
--- a/TENANT_MATRIX.md
+++ b/TENANT_MATRIX.md
@@ -48,6 +48,13 @@ Each option is demonstrated in a dedicated example.
   * **Required**: Must provide IP rules when deny traffic is enabled
   * Example: [`examples/tenant-keyvault-deny/`](examples/tenant-keyvault-deny/)
 
+* **Private networking** - Fully disable public network access on the Key Vault
+  * Variable: `key_vault_private_network = true`
+  * **Note**: Terraform cannot write to a private vault, so you must add the
+    `upwind-client-id` and `upwind-client-secret` secrets manually (scanner credentials are not passed to Terraform)
+  * Mutually exclusive with `key_vault_deny_traffic`
+  * Example: [`examples/tenant-keyvault-private/`](examples/tenant-keyvault-private/)
+
 * **Allow traffic** - Default, allow all traffic
   * Variable: `key_vault_deny_traffic = false` (default)
   * Example: [`examples/tenant-basic/`](examples/tenant-basic/)
@@ -63,4 +70,5 @@ Each option is demonstrated in a dedicated example.
 | [tenant-no-cloudscanner](examples/tenant-no-cloudscanner/) | Tenant | ❌ | ❌ | N/A |
 | [tenant-with-tags](examples/tenant-with-tags/) | Tenant | ✅ | ✅ | Allow |
 | [tenant-keyvault-deny](examples/tenant-keyvault-deny/) | Tenant | ✅ | ❌ | Deny |
+| [tenant-keyvault-private](examples/tenant-keyvault-private/) | Tenant | ✅ | ❌ | Private |
 | [tenant-advanced](examples/tenant-advanced/) | Exclude Subs | ✅ | ✅ | Deny |

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ Additional configuration options:
 
 - **[tenant-with-tags](tenant-with-tags/)** - Apply custom tags to all resources
 - **[tenant-keyvault-deny](tenant-keyvault-deny/)** - Secure Key Vault with network restrictions
+- **[tenant-keyvault-private](tenant-keyvault-private/)** - Fully private Key Vault (secrets added manually)
 
 ### Advanced Examples
 
@@ -55,6 +56,7 @@ Production-ready configurations:
 | [tenant-no-cloudscanner](tenant-no-cloudscanner/) | Tenant | ❌ | ❌ | N/A | Discovery only |
 | [tenant-with-tags](tenant-with-tags/) | Tenant | ✅ | ✅ | Allow | Compliance/cost tracking |
 | [tenant-keyvault-deny](tenant-keyvault-deny/) | Tenant | ✅ | ❌ | Deny | Enhanced security |
+| [tenant-keyvault-private](tenant-keyvault-private/) | Tenant | ✅ | ❌ | Private | No public vault access |
 | [tenant-advanced](tenant-advanced/) | Exclude Subs | ✅ | ✅ | Deny | Production deployment |
 
 ## Choosing an Example
@@ -77,7 +79,8 @@ Production-ready configurations:
 → Use [tenant-with-tags](tenant-with-tags/)
 
 **Security requirements for Key Vault?**
-→ Use [tenant-keyvault-deny](tenant-keyvault-deny/)
+→ Use [tenant-keyvault-deny](tenant-keyvault-deny/) for IP-restricted access,
+or [tenant-keyvault-private](tenant-keyvault-private/) for a fully private vault
 
 **Production deployment with multiple features?**
 → Use [tenant-advanced](tenant-advanced/)
@@ -151,12 +154,20 @@ tags = {
 
 ### Key Vault Security
 
+Restrict access to specific IPs (Terraform still writes the secrets from an allowed IP):
+
 ```hcl
 key_vault_deny_traffic = true
 key_vault_ip_rules = [
   "203.0.113.42",      # Your IP
   "198.51.100.0/24"    # Office network
 ]
+```
+
+Or fully disable public network access (you add the scanner secrets manually afterwards):
+
+```hcl
+key_vault_private_network = true
 ```
 
 ## Prerequisites

--- a/examples/tenant-keyvault-private/README.md
+++ b/examples/tenant-keyvault-private/README.md
@@ -1,0 +1,78 @@
+# Tenant Onboarding With A Private Networking Key Vault
+
+This example provisions the CloudScanner Key Vault with **public network access fully
+disabled** (private networking). Because a private Key Vault is not reachable from the
+public internet, Terraform cannot write secrets into it. Instead, **you** take on the
+responsibility of adding the scanner credentials to the vault after the apply completes.
+
+## Features
+
+- **Scoping**: Tenant level (monitors entire Azure tenant)
+- **CloudScanner**: Enabled
+- **Tags**: None
+- **Key Vault**: Private networking (`public_network_access_enabled = false`)
+
+## Configuration
+
+This example uses:
+
+- `azure_tenant_id` to scope monitoring to the entire tenant
+- `key_vault_private_network = true` to fully disable public network access on the Key Vault
+- No scanner credentials are passed to Terraform - CloudScanner infrastructure is still
+  provisioned, but the secrets are added to the Key Vault manually
+
+## Use Case
+
+Use this approach when your security policy requires that the CloudScanner Key Vault has no
+public network exposure at all, and you are able to add secrets to the vault yourself through
+a private path (e.g. from a peered network, a jump host, or a private endpoint).
+
+## How It Differs From `tenant-keyvault-deny`
+
+| | `tenant-keyvault-deny` | `tenant-keyvault-private` |
+|---|---|---|
+| Public network access | Enabled, restricted by IP allowlist | **Disabled** |
+| Variable | `key_vault_deny_traffic` + `key_vault_ip_rules` | `key_vault_private_network` |
+| Who writes the secrets | Terraform (from an allowed IP) | **You, manually** |
+| `scanner_client_id` / `scanner_client_secret` | Required | Not used |
+
+These two options are mutually exclusive - you cannot set both `key_vault_private_network`
+and `key_vault_deny_traffic` at the same time.
+
+## Important: You Must Add The Secrets Manually
+
+Terraform creates the Key Vault and all CloudScanner infrastructure, but it does **not**
+create the `upwind-client-id` and `upwind-client-secret` secrets, because it cannot reach a
+private vault. After the apply, add them yourself.
+
+1. Run the apply:
+
+   ```bash
+   terraform init
+   terraform plan
+   terraform apply
+   ```
+
+2. Note the `key_vault_name` output:
+
+   ```text
+   Outputs:
+
+   key_vault_name = "kv-<hash><suffix>"
+   ```
+
+3. Find that Key Vault in the Azure portal (or via a private path you control) and add two
+   secrets with these **exact** names:
+
+   - `upwind-client-id` - the `AzureScannersReportingCredentials` **client id** value from
+     the Upwind console.
+   - `upwind-client-secret` - the `AzureScannersReportingCredentials` **client secret** value
+     from the Upwind console.
+
+   CloudScanner will not be able to authenticate until both secrets are present.
+
+## Clean Up
+
+```bash
+terraform destroy
+```

--- a/examples/tenant-keyvault-private/main.tf
+++ b/examples/tenant-keyvault-private/main.tf
@@ -1,0 +1,51 @@
+# Tenant Onboarding With A Private Networking Key Vault
+# This example provisions the CloudScanner Key Vault with public network access fully
+# disabled. Because Terraform cannot reach a private vault to write secrets, the scanner
+# credentials must be added to the vault manually after apply (see the notes below).
+
+locals {
+  azure_tenant_id                    = "12345678-1234-1234-1234-123456789012"
+  azure_orchestrator_subscription_id = "87654321-4321-4321-4321-210987654321"
+}
+
+provider "azurerm" {
+  subscription_id                = local.azure_orchestrator_subscription_id
+  resource_providers_to_register = ["Microsoft.App"]
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+    key_vault {
+      recover_soft_deleted_keys       = true
+      recover_soft_deleted_secrets    = true
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+provider "azuread" {
+  tenant_id = local.azure_tenant_id
+}
+
+module "upwind_integration_azure_onboarding" {
+  source = "upwindsecurity/onboarding/azurerm//modules/tenant"
+
+  # Upwind organization configuration
+  upwind_organization_id = "org_example12345"
+  upwind_client_id       = "upwind_client_id_example"
+  upwind_client_secret   = "upwind_client_secret_example"
+
+  # Azure configuration - Tenant level scope
+  azure_tenant_id                    = local.azure_tenant_id
+  azure_orchestrator_subscription_id = local.azure_orchestrator_subscription_id
+  azure_cloudscanner_location        = "westus"
+
+  # Private networking Key Vault.
+  # Public network access is disabled and Terraform does NOT create the scanner secrets -
+  # you must add 'upwind-client-id' and 'upwind-client-secret' to the vault yourself.
+  # Note: scanner_client_id / scanner_client_secret are intentionally omitted; they would
+  # be unreachable to write and are supplied manually instead.
+  key_vault_private_network = true
+
+  resource_suffix = "example"
+}

--- a/examples/tenant-keyvault-private/outputs.tf
+++ b/examples/tenant-keyvault-private/outputs.tf
@@ -1,0 +1,21 @@
+output "azure_application_client_id" {
+  description = "The unique identifier for the Azure AD application (client)."
+  value       = module.upwind_integration_azure_onboarding.azure_application_client_id
+  sensitive   = true
+}
+
+output "azure_application_client_secret" {
+  description = "The client secret for the Azure AD application."
+  value       = module.upwind_integration_azure_onboarding.azure_application_client_secret
+  sensitive   = true
+}
+
+output "azure_tenant_id" {
+  description = "The unique identifier for the Azure tenant."
+  value       = module.upwind_integration_azure_onboarding.azure_tenant_id
+}
+
+output "key_vault_name" {
+  description = "The name of the private Key Vault. Add the scanner credentials from the Upwind console to this vault as secrets named 'upwind-client-id' and 'upwind-client-secret'."
+  value       = module.upwind_integration_azure_onboarding.key_vault_name
+}

--- a/examples/tenant-keyvault-private/variables.tf
+++ b/examples/tenant-keyvault-private/variables.tf
@@ -1,0 +1,2 @@
+# No input variables required for this example.
+# All configuration is done through local values in main.tf.

--- a/examples/tenant-keyvault-private/versions.tf
+++ b/examples/tenant-keyvault-private/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.42.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.53.0"
+    }
+  }
+}

--- a/modules/tenant/README.md
+++ b/modules/tenant/README.md
@@ -4,11 +4,10 @@ This Terraform module handles the onboarding of Microsoft Azure tenants to the U
 seamlessly connect their entire tenant for comprehensive monitoring and security analysis.
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.53 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.42 |
@@ -20,12 +19,12 @@ seamlessly connect their entire tenant for comprehensive monitoring and security
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >= 2.53 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.42 |
-| <a name="provider_http"></a> [http](#provider\_http) | >= 3.4 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5 |
-| <a name="provider_time"></a> [time](#provider\_time) | >= 0.8 |
+|------|---------|
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.8.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.72.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.13.1 |
 
 ## Modules
 
@@ -34,7 +33,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_application_api_access.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_api_access) | resource |
 | [azuread_application_password.client_secret](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
@@ -99,7 +98,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_azure_application_client_id"></a> [azure\_application\_client\_id](#input\_azure\_application\_client\_id) | Optional client ID of an existing Azure AD application. If provided, the module will use this existing application instead of creating a new one. Mutually exclusive with azure\_application\_name\_prefix. MSGraph permissions need to be configured manually for the existing application. Note: for a multi-tenant application registered in a different tenant, a service principal for the application must already exist in the tenant being onboarded (e.g. created via `az ad sp create --id <client_id>` or via admin consent at <https://login.microsoftonline.com/{tenant_id}/adminconsent?client_id={app_id}>) before running this module. In the multi-tenant case you must also set azure\_application\_service\_principal\_object\_id — otherwise the data-source lookup of the application object fails at plan time, because the app registration lives in the home tenant and is not visible to the runner. | `string` | `null` | no |
 | <a name="input_azure_application_client_secret"></a> [azure\_application\_client\_secret](#input\_azure\_application\_client\_secret) | Client secret for the existing Azure AD application. Required when azure\_application\_client\_id is provided and organizational credentials will be created. Should be managed externally (e.g., Azure Portal, CLI, or separate automation). | `string` | `null` | no |
 | <a name="input_azure_application_msgraph_roles"></a> [azure\_application\_msgraph\_roles](#input\_azure\_application\_msgraph\_roles) | List of Microsoft Graph API roles that should be granted to the Azure AD application. These permissions are required for platform functionality and will be applied to both new and existing applications. | `list(string)` | <pre>[<br/>  "User.Read.All",<br/>  "Group.Read.All",<br/>  "RoleManagement.Read.All",<br/>  "Directory.Read.All",<br/>  "Policy.Read.All",<br/>  "UserAuthenticationMethod.Read.All"<br/>]</pre> | no |
@@ -127,6 +126,7 @@ No modules.
 | <a name="input_key_vault_ip_rules"></a> [key\_vault\_ip\_rules](#input\_key\_vault\_ip\_rules) | One or more IP Addresses, or CIDR Blocks which should be able to access the Key Vault. This is only relevant if key\_vault\_deny\_traffic is set to true. | `list(string)` | `[]` | no |
 | <a name="input_key_vault_logging_enabled"></a> [key\_vault\_logging\_enabled](#input\_key\_vault\_logging\_enabled) | Whether to enable diagnostic logging for the Key Vault. When true, creates a Log Analytics Workspace and configures diagnostic settings to capture AuditEvent logs and AllMetrics. | `bool` | `false` | no |
 | <a name="input_key_vault_logging_retention_in_days"></a> [key\_vault\_logging\_retention\_in\_days](#input\_key\_vault\_logging\_retention\_in\_days) | The number of days to retain logs in the Log Analytics Workspace. Only relevant if key\_vault\_logging\_enabled is true. | `number` | `30` | no |
+| <a name="input_key_vault_private_network"></a> [key\_vault\_private\_network](#input\_key\_vault\_private\_network) | Whether to provision the Key Vault with public network access fully disabled (private networking). When true, Terraform cannot reach the vault to write secrets, so the module will NOT create the 'upwind-client-id' and 'upwind-client-secret' secrets - you must add them manually (see the key\_vault\_name output). CloudScanner infrastructure is still provisioned without needing scanner\_client\_id/scanner\_client\_secret. Cannot be combined with key\_vault\_deny\_traffic. | `bool` | `false` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to append to all resources created by this module. | `string` | `""` | no |
 | <a name="input_saas_enabled"></a> [saas\_enabled](#input\_saas\_enabled) | Enable SaaS (provider-hosted, secretless) onboarding. When true, the customer tenant only consents to Upwind's multi-tenant Snapshot and Fetcher app registrations and assigns them scoped roles at management-group (tenant-root) scope. No app registration, Key Vault, managed identities, custom roles, scanner credentials, or Upwind API calls are created. Self-hosted resources are skipped. Defaults to false (self-hosted, unchanged). | `bool` | `false` | no |
 | <a name="input_scanner_client_id"></a> [scanner\_client\_id](#input\_scanner\_client\_id) | The client ID used for authentication with the Upwind CloudScanner Service. | `string` | `""` | no |
@@ -145,13 +145,14 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_azure_application_client_id"></a> [azure\_application\_client\_id](#output\_azure\_application\_client\_id) | The unique identifier for the Azure AD application (client). |
 | <a name="output_azure_application_client_secret"></a> [azure\_application\_client\_secret](#output\_azure\_application\_client\_secret) | The client secret for the Azure AD application. |
 | <a name="output_azure_application_name"></a> [azure\_application\_name](#output\_azure\_application\_name) | The display name for the Azure AD application. |
 | <a name="output_azure_service_principal_id"></a> [azure\_service\_principal\_id](#output\_azure\_service\_principal\_id) | The unique identifier for the Azure AD service principal. |
 | <a name="output_azure_tenant_id"></a> [azure\_tenant\_id](#output\_azure\_tenant\_id) | The unique identifier for the current Azure tenant. |
 | <a name="output_key_vault_log_analytics_workspace_id"></a> [key\_vault\_log\_analytics\_workspace\_id](#output\_key\_vault\_log\_analytics\_workspace\_id) | The ID of the Log Analytics Workspace used for Key Vault diagnostic logging, or null if logging is not enabled. |
+| <a name="output_key_vault_name"></a> [key\_vault\_name](#output\_key\_vault\_name) | The name of the CloudScanner Key Vault, or null if CloudScanner is not enabled. When key\_vault\_private\_network is true, add the scanner credentials from the Upwind console to this vault as secrets named 'upwind-client-id' and 'upwind-client-secret' (names must be exact). |
 | <a name="output_organizational_credentials"></a> [organizational\_credentials](#output\_organizational\_credentials) | The Upwind organizational credentials that were created to onboard the Azure tenant. |
 | <a name="output_pending_tenant"></a> [pending\_tenant](#output\_pending\_tenant) | The tenant ID that is pending onboarding, or null if already onboarded. |
 | <a name="output_saas_fetcher_service_principal_object_id"></a> [saas\_fetcher\_service\_principal\_object\_id](#output\_saas\_fetcher\_service\_principal\_object\_id) | SaaS mode: object ID of the Fetcher app registration service principal - supplied via fetcher\_app\_service\_principal\_object\_id, or created by the module (null when saas\_enabled is false). |

--- a/modules/tenant/cloudscanner_general.tf
+++ b/modules/tenant/cloudscanner_general.tf
@@ -1,7 +1,8 @@
 locals {
   # This variable may be marked as sensitive if the scanner_client_id variable is sourced from a sensitive data source (e.g., Key Vault)
   # Always disabled in SaaS mode (no customer-side scanner infrastructure).
-  cloudscanner_enabled_sensitive = !var.saas_enabled && var.azure_orchestrator_subscription_id != "" && var.scanner_client_id != ""
+  # In private network mode the customer supplies the scanner secrets directly to the Key Vault, so scanner_client_id is not required to enable CloudScanner.
+  cloudscanner_enabled_sensitive = !var.saas_enabled && var.azure_orchestrator_subscription_id != "" && (var.scanner_client_id != "" || var.key_vault_private_network)
 
   # Remove sensitive marking if present (e.g., from Key Vault data source), otherwise use value as-is
   # This handles both plaintext and sensitive-marked values gracefully

--- a/modules/tenant/cloudscanner_secrets.tf
+++ b/modules/tenant/cloudscanner_secrets.tf
@@ -19,6 +19,10 @@ resource "azurerm_key_vault" "orgwide_key_vault" {
   soft_delete_retention_days = 7
   purge_protection_enabled   = true
 
+  # Fully disable public network access when running in private network mode.
+  # In that mode Terraform cannot reach the vault, so the scanner secrets are added manually by the customer.
+  public_network_access_enabled = !var.key_vault_private_network
+
   # Deny public access if key_vault_deny_traffic is true
   dynamic "network_acls" {
     for_each = var.key_vault_deny_traffic ? [1] : []
@@ -32,13 +36,13 @@ resource "azurerm_key_vault" "orgwide_key_vault" {
   tags = merge(var.tags, {
     "UpwindComponent"  = "CloudScanner"
     "UpwindOrgId"      = var.upwind_organization_id
-    "DenyPublicAccess" = var.key_vault_deny_traffic ? "true" : "false"
+    "DenyPublicAccess" = var.key_vault_deny_traffic || var.key_vault_private_network ? "true" : "false"
   })
 }
 
 # Create private DNS zone for Key Vault, dns links will be added per cloudscanner deployment
 resource "azurerm_private_dns_zone" "orgwide_keyvault_dns_zone" {
-  count               = local.cloudscanner_enabled && var.key_vault_deny_traffic ? 1 : 0
+  count               = local.cloudscanner_enabled && (var.key_vault_deny_traffic || var.key_vault_private_network) ? 1 : 0
   name                = "privatelink.vaultcore.azure.net"
   resource_group_name = azurerm_resource_group.orgwide_resource_group[0].name
 }
@@ -64,9 +68,12 @@ resource "azurerm_role_assignment" "kv_secrets_scaler" {
   principal_id         = azurerm_user_assigned_identity.scaler_user_assigned_identity[0].principal_id
 }
 
-# Add organization-wide secrets to Key Vault
+# Add organization-wide secrets to Key Vault.
+# Skipped in private network mode: Terraform cannot reach a vault with public network access
+# disabled, so the customer must add 'upwind-client-id' and 'upwind-client-secret' manually
+# (see the key_vault_name output).
 resource "azurerm_key_vault_secret" "scanner_client_id" {
-  count        = local.cloudscanner_enabled ? 1 : 0
+  count        = local.cloudscanner_enabled && !var.key_vault_private_network ? 1 : 0
   name         = "upwind-client-id"
   value        = var.scanner_client_id
   key_vault_id = azurerm_key_vault.orgwide_key_vault[0].id
@@ -75,7 +82,7 @@ resource "azurerm_key_vault_secret" "scanner_client_id" {
 }
 
 resource "azurerm_key_vault_secret" "scanner_client_secret" {
-  count        = local.cloudscanner_enabled ? 1 : 0
+  count        = local.cloudscanner_enabled && !var.key_vault_private_network ? 1 : 0
   name         = "upwind-client-secret"
   value        = var.scanner_client_secret
   key_vault_id = azurerm_key_vault.orgwide_key_vault[0].id

--- a/modules/tenant/outputs.tf
+++ b/modules/tenant/outputs.tf
@@ -39,6 +39,11 @@ output "pending_tenant" {
   description = "The tenant ID that is pending onboarding, or null if already onboarded."
 }
 
+output "key_vault_name" {
+  description = "The name of the CloudScanner Key Vault, or null if CloudScanner is not enabled. When key_vault_private_network is true, add the scanner credentials from the Upwind console to this vault as secrets named 'upwind-client-id' and 'upwind-client-secret' (names must be exact)."
+  value       = local.cloudscanner_enabled ? azurerm_key_vault.orgwide_key_vault[0].name : null
+}
+
 output "key_vault_log_analytics_workspace_id" {
   value       = var.key_vault_logging_enabled && local.cloudscanner_enabled ? azurerm_log_analytics_workspace.kv_logging[0].id : null
   description = "The ID of the Log Analytics Workspace used for Key Vault diagnostic logging, or null if logging is not enabled."

--- a/modules/tenant/variables.tf
+++ b/modules/tenant/variables.tf
@@ -278,6 +278,17 @@ variable "key_vault_ip_rules" {
   default     = []
 }
 
+variable "key_vault_private_network" {
+  type        = bool
+  description = "Whether to provision the Key Vault with public network access fully disabled (private networking). When true, Terraform cannot reach the vault to write secrets, so the module will NOT create the 'upwind-client-id' and 'upwind-client-secret' secrets - you must add them manually (see the key_vault_name output). CloudScanner infrastructure is still provisioned without needing scanner_client_id/scanner_client_secret. Cannot be combined with key_vault_deny_traffic."
+  default     = false
+
+  validation {
+    condition     = !(var.key_vault_private_network && var.key_vault_deny_traffic)
+    error_message = "key_vault_private_network and key_vault_deny_traffic are mutually exclusive. Use key_vault_private_network for a fully private vault, or key_vault_deny_traffic with key_vault_ip_rules for IP-restricted public access."
+  }
+}
+
 variable "key_vault_logging_enabled" {
   type        = bool
   description = "Whether to enable diagnostic logging for the Key Vault. When true, creates a Log Analytics Workspace and configures diagnostic settings to capture AuditEvent logs and AllMetrics."


### PR DESCRIPTION
## Summary

Adds support for onboarding a tenant with a **private networking Key Vault** (public network access fully disabled), based on the customized fork we built for a customer. Because a private vault is unreachable from the public internet, Terraform cannot write secrets into it — so in this mode the customer takes on the responsibility of adding the scanner credentials to the vault manually.

This is implemented as an opt-in, backward-compatible variable rather than a fork.

## Changes

**`modules/tenant/`**
- New `key_vault_private_network` variable (bool, default `false`). Mutually exclusive with `key_vault_deny_traffic` (validated).
- When enabled:
  - Key Vault is created with `public_network_access_enabled = false`.
  - The `upwind-client-id` / `upwind-client-secret` secrets are **not** created by Terraform — the customer adds them manually.
  - CloudScanner infrastructure is still provisioned **without** requiring `scanner_client_id` / `scanner_client_secret`.
  - The private DNS zone and `DenyPublicAccess` tag are applied.
- New `key_vault_name` output so the operator knows which vault to populate.

**Example**
- New `examples/tenant-keyvault-private/` mirroring `tenant-keyvault-deny`, documenting the manual secret step (`upwind-client-id` / `upwind-client-secret`, exact names).

**Docs**
- Updated `TENANT_MATRIX.md`, `examples/README.md`, and the auto-generated module `README.md`.

## How it differs from `tenant-keyvault-deny`

| | `key_vault_deny_traffic` | `key_vault_private_network` |
|---|---|---|
| Public network access | Enabled, IP-restricted | **Disabled** |
| Who writes the secrets | Terraform (from an allowed IP) | **The customer, manually** |
| Scanner credentials required | Yes | No |

## Testing

- `terraform validate` passes on the tenant module.
- The new example validates against the **local** module source (verified manually).
- `tflint` clean on the module.
- All pre-commit hooks pass except `terraform_validate` on the new example, which references the published registry module and cannot resolve the new variable until this is released — same registry-lag limitation that affects any new-variable + example PR here. CI only validates modules (examples are opt-in), so this does not block CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)