### PR TITLE
fix(UP-3155): wait for kv admin role propagation before writing secrets

### DIFF
--- a/modules/tenant/README.md
+++ b/modules/tenant/README.md
@@ -83,6 +83,7 @@ No modules.
 | [time_sleep.cloudscanner_scaler_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.cloudscanner_worker_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.deployer_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [time_sleep.kv_admin_role_assignment_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.saas_snapshot_target_role_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.target_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/application_published_app_ids) | data source |

--- a/modules/tenant/cloudscanner_secrets.tf
+++ b/modules/tenant/cloudscanner_secrets.tf
@@ -68,6 +68,16 @@ resource "azurerm_role_assignment" "kv_secrets_scaler" {
   principal_id         = azurerm_user_assigned_identity.scaler_user_assigned_identity[0].principal_id
 }
 
+# Wait for the Key Vault Administrator role assignment to propagate to the vault data plane
+# before writing secrets. RBAC assignments are eventually consistent: depends_on guarantees the
+# assignment is created in ARM, but not that it has reached the data plane. Without this wait the
+# first apply fails with a 403 on the secret write and only succeeds on a subsequent apply.
+resource "time_sleep" "kv_admin_role_assignment_wait" {
+  count           = local.cloudscanner_enabled && !var.key_vault_private_network ? 1 : 0
+  depends_on      = [azurerm_role_assignment.kv_admin]
+  create_duration = var.azure_role_definition_wait_time
+}
+
 # Add organization-wide secrets to Key Vault.
 # Skipped in private network mode: Terraform cannot reach a vault with public network access
 # disabled, so the customer must add 'upwind-client-id' and 'upwind-client-secret' manually
@@ -77,7 +87,7 @@ resource "azurerm_key_vault_secret" "scanner_client_id" {
   name         = "upwind-client-id"
   value        = var.scanner_client_id
   key_vault_id = azurerm_key_vault.orgwide_key_vault[0].id
-  depends_on   = [azurerm_role_assignment.kv_admin]
+  depends_on   = [time_sleep.kv_admin_role_assignment_wait]
   tags         = var.tags
 }
 
@@ -86,7 +96,7 @@ resource "azurerm_key_vault_secret" "scanner_client_secret" {
   name         = "upwind-client-secret"
   value        = var.scanner_client_secret
   key_vault_id = azurerm_key_vault.orgwide_key_vault[0].id
-  depends_on   = [azurerm_role_assignment.kv_admin]
+  depends_on   = [time_sleep.kv_admin_role_assignment_wait]
   tags         = var.tags
 }
 


### PR DESCRIPTION
## Summary

`azurerm_key_vault_secret.scanner_client_id`/`scanner_client_secret` depended only on `azurerm_role_assignment.kv_admin` via `depends_on`. That guarantees ARM *creation* order but **not** data-plane RBAC *propagation*. Because the org-wide vault runs with `rbac_authorization_enabled = true`, writing a secret requires the Terraform principal to hold Key Vault Administrator at the data plane, which is eventually consistent.

Symptom reported by a customer: after relaxing an Azure Policy that had blocked vault creation, the vault was created but the **secrets did not get created until a second plan/apply** — the first apply raced ahead of RBAC propagation and hit a 403 on the secret write.

## Fix

Insert a `time_sleep.kv_admin_role_assignment_wait` between the `Key Vault Administrator` role assignment and the secrets, mirroring the module's existing propagation-wait pattern (`builtin_role_assignment_wait`, and the role-definition waits in `cloudscanner_iam.tf`) and reusing the `azure_role_definition_wait_time` variable. The wait is skipped in private-network mode, where Terraform does not create the secrets at all.

## Testing

- Pre-commit hooks pass: fmt, validate, tflint, trivy, terraform-docs, markdownlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)