### PR TITLE
feat(UP-3130): make DSPM opt-in via the marker role, keep function scanning always on

### DIFF
--- a/modules/tenant/README.md
+++ b/modules/tenant/README.md
@@ -4,10 +4,11 @@ This Terraform module handles the onboarding of Microsoft Azure tenants to the U
 seamlessly connect their entire tenant for comprehensive monitoring and security analysis.
 
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.53 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.42 |
@@ -19,12 +20,12 @@ seamlessly connect their entire tenant for comprehensive monitoring and security
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.8.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.72.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | 3.5.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.8.1 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.13.1 |
+| ---- | ------- |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 3.9.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.81.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | 3.6.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.14.0 |
 
 ## Modules
 
@@ -33,7 +34,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azuread_application.this](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_application_api_access.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_api_access) | resource |
 | [azuread_application_password.client_secret](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application_password) | resource |
@@ -54,6 +55,7 @@ No modules.
 | [azurerm_role_assignment.custom](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.deployer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.disk_encryption_key_vault_access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.dspm_marker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.kv_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.kv_secrets_scaler](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.kv_secrets_worker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -71,6 +73,7 @@ No modules.
 | [azurerm_role_definition.cloudscanner_worker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.custom](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.deployer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.dspm_marker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.saas_dspm_marker](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.saas_fetcher_custom_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.saas_snapshot_target_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
@@ -85,6 +88,7 @@ No modules.
 | [time_sleep.cloudscanner_scaler_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.cloudscanner_worker_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.deployer_role_definition_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [time_sleep.dspm_marker_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.kv_admin_role_assignment_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.saas_dspm_marker_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [time_sleep.saas_snapshot_target_role_wait](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
@@ -102,7 +106,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_azure_application_client_id"></a> [azure\_application\_client\_id](#input\_azure\_application\_client\_id) | Optional client ID of an existing Azure AD application. If provided, the module will use this existing application instead of creating a new one. Mutually exclusive with azure\_application\_name\_prefix. MSGraph permissions need to be configured manually for the existing application. Note: for a multi-tenant application registered in a different tenant, a service principal for the application must already exist in the tenant being onboarded (e.g. created via `az ad sp create --id <client_id>` or via admin consent at <https://login.microsoftonline.com/{tenant_id}/adminconsent?client_id={app_id}>) before running this module. In the multi-tenant case you must also set azure\_application\_service\_principal\_object\_id — otherwise the data-source lookup of the application object fails at plan time, because the app registration lives in the home tenant and is not visible to the runner. | `string` | `null` | no |
 | <a name="input_azure_application_client_secret"></a> [azure\_application\_client\_secret](#input\_azure\_application\_client\_secret) | Client secret for the existing Azure AD application. Required when azure\_application\_client\_id is provided and organizational credentials will be created. Should be managed externally (e.g., Azure Portal, CLI, or separate automation). | `string` | `null` | no |
 | <a name="input_azure_application_msgraph_roles"></a> [azure\_application\_msgraph\_roles](#input\_azure\_application\_msgraph\_roles) | List of Microsoft Graph API roles that should be granted to the Azure AD application. These permissions are required for platform functionality and will be applied to both new and existing applications. | `list(string)` | <pre>[<br/>  "User.Read.All",<br/>  "Group.Read.All",<br/>  "RoleManagement.Read.All",<br/>  "Directory.Read.All",<br/>  "Policy.Read.All",<br/>  "UserAuthenticationMethod.Read.All"<br/>]</pre> | no |
@@ -122,7 +126,7 @@ No modules.
 | <a name="input_cloudscanner_exclude_subscriptions"></a> [cloudscanner\_exclude\_subscriptions](#input\_cloudscanner\_exclude\_subscriptions) | Optional list of subscription IDs to exclude from cloudscanner managed identity role assignments. If provided, cloudscanner roles will be assigned at the subscription level to all tenant subscriptions except these (instead of at management group level). Mutually exclusive with cloudscanner\_include\_subscriptions. Note: When used with azure\_management\_group\_ids, role assignments switch from management-group-level to subscription-level for all tenant subscriptions (excluding specified ones). This will enable us to exclude subscriptions from the scanning process. Cloudscanner scope should be a subset of cloudapi scope. | `list(string)` | `[]` | no |
 | <a name="input_cloudscanner_include_subscriptions"></a> [cloudscanner\_include\_subscriptions](#input\_cloudscanner\_include\_subscriptions) | Optional list of subscription IDs to include for cloudscanner managed identity role assignments. If provided, cloudscanner roles will only be assigned to these subscriptions. Mutually exclusive with cloudscanner\_exclude\_subscriptions. Can be combined with azure\_management\_group\_ids or azure\_tenant\_id. This will enable us to scan resources in these subscriptions. Cloudscanner scope should be a subset of cloudapi scope. | `list(string)` | `[]` | no |
 | <a name="input_create_organizational_credentials"></a> [create\_organizational\_credentials](#input\_create\_organizational\_credentials) | Set to false to skip sending organizational credentials to Upwind. The default value for this variable should be set to true for onboarding deployments using 'terraform init && terraform apply' and set to false when offboarding using 'terraform destroy'. It is essential that it is reset appropriately for subsequent deploy / destroy attempts. | `bool` | `true` | no |
-| <a name="input_disable_function_scanning"></a> [disable\_function\_scanning](#input\_disable\_function\_scanning) | Legacy opt-out (poorly named): if true, disables the Storage Blob Data Reader / Storage File Data Privileged Reader grants that back DSPM. Retained for backwards compatibility; prefer upwind\_feature\_dspm\_enabled to control DSPM. DSPM is enabled only when upwind\_feature\_dspm\_enabled is true AND this is false. | `bool` | `false` | no |
+| <a name="input_disable_function_scanning"></a> [disable\_function\_scanning](#input\_disable\_function\_scanning) | Opt-out for Azure Function scanning (on by default): if true, the Storage Blob Data Reader / Storage File Data Privileged Reader grants are not assigned. DSPM reads data via the same grants, so setting this true also disables DSPM (the DSPM marker role is not minted regardless of upwind\_feature\_dspm\_enabled). | `bool` | `false` | no |
 | <a name="input_fetcher_app_client_id"></a> [fetcher\_app\_client\_id](#input\_fetcher\_app\_client\_id) | SaaS mode: client ID of Upwind's multi-tenant Fetcher app registration. Its service principal is materialized in the customer tenant and granted, at the tenant-root management group, the outpost app-registration role set: the built-in read roles (var.azure\_roles) + a custom role (var.azure\_custom\_role\_permissions). Required when saas\_enabled is true, unless fetcher\_app\_service\_principal\_object\_id is provided. | `string` | `""` | no |
 | <a name="input_fetcher_app_service_principal_object_id"></a> [fetcher\_app\_service\_principal\_object\_id](#input\_fetcher\_app\_service\_principal\_object\_id) | SaaS mode (optional): object ID of an existing service principal for Upwind's Fetcher app registration in the customer tenant. Provide this when the SP has already been created out-of-band (e.g. via admin consent / `az ad sp create`) and the Terraform runner lacks Microsoft Graph permissions to create it. When set, the module skips creating the service principal and assigns roles to this object ID directly; fetcher\_app\_client\_id is then not required. | `string` | `""` | no |
 | <a name="input_function_storage_accounts"></a> [function\_storage\_accounts](#input\_function\_storage\_accounts) | Optional list of storage account resource IDs used by Function Apps. If provided, Storage Blob Data Reader role will only be assigned to these specific storage accounts instead of all resources in scope. Use the list-function-storage-accounts.sh script to discover these. Example: ["/subscriptions/{sub-id}/resourceGroups/{rg}/providers/Microsoft.Storage/storageAccounts/{name}"] | `list(string)` | `[]` | no |
@@ -142,7 +146,7 @@ No modules.
 | <a name="input_upwind_auth_endpoint"></a> [upwind\_auth\_endpoint](#input\_upwind\_auth\_endpoint) | The Authentication API endpoint. | `string` | `"https://auth.upwind.io"` | no |
 | <a name="input_upwind_client_id"></a> [upwind\_client\_id](#input\_upwind\_client\_id) | The client ID used for authentication with the Upwind Authorization Service. Required for self-hosted onboarding; not used when saas\_enabled is true (SaaS onboarding is secretless and makes no Upwind API call). | `string` | `""` | no |
 | <a name="input_upwind_client_secret"></a> [upwind\_client\_secret](#input\_upwind\_client\_secret) | The client secret for authentication with the Upwind Authorization Service. Required for self-hosted onboarding; not used when saas\_enabled is true. | `string` | `""` | no |
-| <a name="input_upwind_feature_dspm_enabled"></a> [upwind\_feature\_dspm\_enabled](#input\_upwind\_feature\_dspm\_enabled) | Opt-in control for Upwind DSPM (Data Security Posture Management). When true (default), onboarding grants data-plane blob read (Storage Blob Data Reader / Storage File Data Privileged Reader) and, in SaaS mode, mints the DSPM marker role the CloudScanner feature gate detects. Setting this to false ALSO disables Azure Function scanning: Function apps store their code in an Azure storage account, and reading that code relies on the same Storage Blob Data Reader grant - so turning DSPM off removes function-code visibility too. Coexists with the legacy disable\_function\_scanning: DSPM (and function scanning) is provisioned only when this is true AND disable\_function\_scanning is false. | `bool` | `true` | no |
+| <a name="input_upwind_feature_dspm_enabled"></a> [upwind\_feature\_dspm\_enabled](#input\_upwind\_feature\_dspm\_enabled) | Opt-in control for Upwind DSPM (Data Security Posture Management). When true, onboarding mints the DSPM marker role the CloudScanner feature gate detects. The marker is minted when CloudScanner is provisioned (self-hosted) or in SaaS mode; onboardings without CloudScanner mint nothing. Default false: DSPM is opt-in. Gates ONLY the marker role - the storage data-plane read grants (Storage Blob Data Reader / Storage File Data Privileged Reader) are always assigned because Azure Function scanning (on by default) reads function code via the same roles. Ignored (no marker minted) when disable\_function\_scanning is true, since DSPM reads data via those grants. | `bool` | `false` | no |
 | <a name="input_upwind_integration_endpoint"></a> [upwind\_integration\_endpoint](#input\_upwind\_integration\_endpoint) | The Integration API endpoint. | `string` | `"https://integration.upwind.io"` | no |
 | <a name="input_upwind_organization_id"></a> [upwind\_organization\_id](#input\_upwind\_organization\_id) | The identifier of the Upwind organization to integrate with. | `string` | n/a | yes |
 | <a name="input_upwind_region"></a> [upwind\_region](#input\_upwind\_region) | The region where the Upwind components will be deployed. Must be 'us', 'eu', 'ap' or 'me' | `string` | `"us"` | no |
@@ -150,7 +154,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_azure_application_client_id"></a> [azure\_application\_client\_id](#output\_azure\_application\_client\_id) | The unique identifier for the Azure AD application (client). |
 | <a name="output_azure_application_client_secret"></a> [azure\_application\_client\_secret](#output\_azure\_application\_client\_secret) | The client secret for the Azure AD application. |
 | <a name="output_azure_application_name"></a> [azure\_application\_name](#output\_azure\_application\_name) | The display name for the Azure AD application. |

--- a/modules/tenant/cloudscanner_iam.tf
+++ b/modules/tenant/cloudscanner_iam.tf
@@ -3,12 +3,17 @@
 locals {
   resource_suffix = format("%s%s", var.upwind_organization_id, var.resource_suffix)
 
-  # DSPM (data-plane blob read) is enabled only when the customer opts in via
-  # upwind_feature_dspm_enabled AND has not set the legacy disable_function_scanning
-  # opt-out. Either control can turn DSPM off; default is on. Used to gate the
-  # Storage Blob/File data readers (self-hosted below and SaaS in saas.tf) and the
-  # SaaS DSPM marker role.
-  dspm_enabled = var.upwind_feature_dspm_enabled && !var.disable_function_scanning
+  # Storage Blob/File data readers (self-hosted below and SaaS in saas.tf) back Azure
+  # Function code scanning, which is on by default - so they are granted whenever
+  # scanning is provisioned, gated only by the legacy disable_function_scanning opt-out.
+  function_scanning_enabled = !var.disable_function_scanning
+
+  # DSPM is opt-in via upwind_feature_dspm_enabled (default false) and gates ONLY the
+  # DSPM marker role (self-hosted below and SaaS in saas.tf) - the CloudScanner feature
+  # gate's signal that DSPM is enabled for this org. DSPM reads data via the same
+  # storage grants as function scanning, so the disable_function_scanning opt-out also
+  # turns DSPM off.
+  dspm_enabled = var.upwind_feature_dspm_enabled && local.function_scanning_enabled
 
   # Actions granted by CloudScannerTargetRole: target-disk read + begin-access +
   # ACR pull. Shared between the self-hosted (outpost) worker identity and the
@@ -150,8 +155,9 @@ resource "azurerm_role_assignment" "cloudscanner_worker" {
 # Because this is a data action permission, we can't include this in a custom role definition and assign it at a management group scope.
 # If function_storage_accounts is provided, assign to specific storage accounts only.
 # Otherwise, assign to all resources in cloudscanner scope.
+# Not gated on DSPM: function scanning (on by default) reads function code via this grant.
 resource "azurerm_role_assignment" "storage_reader" {
-  for_each = (local.cloudscanner_enabled && local.dspm_enabled) ? (
+  for_each = (local.cloudscanner_enabled && local.function_scanning_enabled) ? (
     length(var.function_storage_accounts) > 0 ?
     toset(var.function_storage_accounts) :
     toset(local.cloudscanner_scopes)
@@ -164,8 +170,9 @@ resource "azurerm_role_assignment" "storage_reader" {
 # Assign Storage File Data Privileged Reader role to the worker identity
 # If function_storage_accounts is provided, assign to specific storage accounts only.
 # Otherwise, assign to all resources in cloudscanner scope.
+# Not gated on DSPM: function scanning (on by default) reads function code via this grant.
 resource "azurerm_role_assignment" "storage_file_reader" {
-  for_each = (local.cloudscanner_enabled && local.dspm_enabled) ? (
+  for_each = (local.cloudscanner_enabled && local.function_scanning_enabled) ? (
     length(var.function_storage_accounts) > 0 ?
     toset(var.function_storage_accounts) :
     toset(local.cloudscanner_scopes)
@@ -178,7 +185,7 @@ resource "azurerm_role_assignment" "storage_file_reader" {
 
 # Assign a least-privilege App Service SCM bearer role to the worker identity
 resource "azurerm_role_definition" "app_service_scm_bearer_reader" {
-  for_each = (local.cloudscanner_enabled && !var.disable_function_scanning) ? toset(local.cloudscanner_scopes) : []
+  for_each = (local.cloudscanner_enabled && local.function_scanning_enabled) ? toset(local.cloudscanner_scopes) : []
 
   name        = "CloudScannerAppServiceScmRole-${local.resource_suffix}-${split("/", each.value)[length(split("/", each.value)) - 1]}"
   description = "Role for CloudScanner workers to read App Service metadata and access SCM with bearer authentication in this scope"
@@ -193,7 +200,7 @@ resource "azurerm_role_definition" "app_service_scm_bearer_reader" {
 }
 
 resource "time_sleep" "app_service_scm_bearer_reader_role_definition_wait" {
-  count           = (local.cloudscanner_enabled && !var.disable_function_scanning) ? 1 : 0
+  count           = (local.cloudscanner_enabled && local.function_scanning_enabled) ? 1 : 0
   depends_on      = [azurerm_role_definition.app_service_scm_bearer_reader]
   create_duration = var.azure_role_definition_wait_time
 }
@@ -312,6 +319,52 @@ resource "azurerm_role_assignment" "target_role_assignment" {
   principal_id       = azurerm_user_assigned_identity.worker_user_assigned_identity[0].principal_id
   scope              = each.value.scope
   depends_on         = [time_sleep.target_role_definition_wait[0]]
+}
+
+# endregion
+
+# region DSPM marker
+
+# DSPM feature-gate marker role, minted per scope only when DSPM is opted in
+# (upwind_feature_dspm_enabled). Gives CloudScanner's DSPM feature gate a Graph-free
+# signal that DSPM is enabled for this org: the role carries only a benign
+# management-plane read (no dataActions), and role definitions are collected via
+# management-plane reads, so the gate detects it via
+# SearchAzureRoleDefinitions(roleName like "UpwindDSPMEnabled-{orgID}%").
+#
+# The "UpwindDSPMEnabled" name prefix is a contract with cloudscanner
+# cloudproviders.DSPMRolePrefix, the saas.tf saas_dspm_marker role and the serverless
+# mg-roles/sub-roles/saas-mg-roles.bicep dspmMarkerRole - a rename must move on all
+# sides together. In SaaS mode cloudscanner_enabled is always false (see
+# cloudscanner_general.tf), so this never overlaps the identically named marker
+# saas.tf mints there.
+resource "azurerm_role_definition" "dspm_marker" {
+  for_each    = (local.cloudscanner_enabled && local.dspm_enabled) ? toset(local.cloudscanner_scopes) : []
+  name        = "UpwindDSPMEnabled-${local.resource_suffix}-${split("/", each.value)[length(split("/", each.value)) - 1]}"
+  description = "Marker role signalling that Upwind DSPM is enabled for this org; detected by the CloudScanner DSPM feature gate."
+  scope       = each.value
+  permissions {
+    actions = ["Microsoft.Storage/storageAccounts/read"]
+  }
+}
+
+resource "time_sleep" "dspm_marker_wait" {
+  count           = (local.cloudscanner_enabled && local.dspm_enabled) ? 1 : 0
+  depends_on      = [azurerm_role_definition.dspm_marker]
+  create_duration = var.azure_role_definition_wait_time
+}
+
+# Worker identity -> DSPM marker role at each scope. Assigning (not just defining) keeps
+# the marker from reading as orphaned to cleanup tooling. The role carries only
+# management-plane storage-account metadata read (no dataActions); note that when
+# function_storage_accounts narrows the data readers to specific accounts, this still
+# lets the worker ENUMERATE storage accounts across the scope (metadata only, no data).
+resource "azurerm_role_assignment" "dspm_marker" {
+  for_each           = azurerm_role_definition.dspm_marker
+  role_definition_id = each.value.role_definition_resource_id
+  principal_id       = azurerm_user_assigned_identity.worker_user_assigned_identity[0].principal_id
+  scope              = each.value.scope
+  depends_on         = [time_sleep.dspm_marker_wait[0]]
 }
 
 # endregion

--- a/modules/tenant/saas.tf
+++ b/modules/tenant/saas.tf
@@ -52,15 +52,18 @@ locals {
     "${pair[0]}|${pair[1]}" => { scope = pair[0], role = pair[1] }
   } : {}
 
-  # Snapshot SP worker data-plane roles. These back DSPM (blob/file content read), so
-  # they are gated on DSPM being enabled (local.dspm_enabled) in addition to saas_enabled.
-  saas_snapshot_worker_role_assignments = (var.saas_enabled && local.dspm_enabled) ? {
+  # Snapshot SP worker data-plane roles. Not gated on DSPM: Azure Function code
+  # scanning (on by default) reads function code via these same grants, so they are
+  # assigned whenever SaaS scanning is provisioned, subject only to the legacy
+  # disable_function_scanning opt-out.
+  saas_snapshot_worker_role_assignments = (var.saas_enabled && local.function_scanning_enabled) ? {
     for pair in setproduct(local.normalized_management_group_ids, local.saas_snapshot_worker_roles) :
     "${pair[0]}|${pair[1]}" => { scope = pair[0], role = pair[1] }
   } : {}
 
-  # DSPM marker role scopes - minted only when DSPM is enabled, alongside the worker
-  # data-plane grant above, so "marker exists <=> DSPM provisioned" holds.
+  # DSPM marker role scopes - minted only when DSPM is opted in
+  # (upwind_feature_dspm_enabled), so "marker exists <=> DSPM enabled" holds. The
+  # storage grants above are always assigned and no longer signal anything.
   saas_dspm_marker_scopes = (var.saas_enabled && local.dspm_enabled) ? toset(local.normalized_management_group_ids) : []
 
   # Snapshot SP CloudScannerTargetRole scopes (target-disk read + begin-access +

--- a/modules/tenant/variables.tf
+++ b/modules/tenant/variables.tf
@@ -210,15 +210,15 @@ variable "azure_cloudscanner_location" {
 }
 
 variable "disable_function_scanning" {
-  description = "Legacy opt-out (poorly named): if true, disables the Storage Blob Data Reader / Storage File Data Privileged Reader grants that back DSPM. Retained for backwards compatibility; prefer upwind_feature_dspm_enabled to control DSPM. DSPM is enabled only when upwind_feature_dspm_enabled is true AND this is false."
+  description = "Opt-out for Azure Function scanning (on by default): if true, the Storage Blob Data Reader / Storage File Data Privileged Reader grants are not assigned. DSPM reads data via the same grants, so setting this true also disables DSPM (the DSPM marker role is not minted regardless of upwind_feature_dspm_enabled)."
   type        = bool
   default     = false
 }
 
 variable "upwind_feature_dspm_enabled" {
-  description = "Opt-in control for Upwind DSPM (Data Security Posture Management). When true (default), onboarding grants data-plane blob read (Storage Blob Data Reader / Storage File Data Privileged Reader) and, in SaaS mode, mints the DSPM marker role the CloudScanner feature gate detects. Setting this to false ALSO disables Azure Function scanning: Function apps store their code in an Azure storage account, and reading that code relies on the same Storage Blob Data Reader grant - so turning DSPM off removes function-code visibility too. Coexists with the legacy disable_function_scanning: DSPM (and function scanning) is provisioned only when this is true AND disable_function_scanning is false."
+  description = "Opt-in control for Upwind DSPM (Data Security Posture Management). When true, onboarding mints the DSPM marker role the CloudScanner feature gate detects. The marker is minted when CloudScanner is provisioned (self-hosted) or in SaaS mode; onboardings without CloudScanner mint nothing. Default false: DSPM is opt-in. Gates ONLY the marker role - the storage data-plane read grants (Storage Blob Data Reader / Storage File Data Privileged Reader) are always assigned because Azure Function scanning (on by default) reads function code via the same roles. Ignored (no marker minted) when disable_function_scanning is true, since DSPM reads data via those grants."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "cloudapi_include_subscriptions" {


### PR DESCRIPTION
## Summary

Decouples DSPM from the storage data-plane grants so Azure Function scanning stays on by default and DSPM becomes a marker-role opt-in on any onboarding mode. Mirrors the upwind-azure-serverless change (same `UpwindDSPMEnabled` naming contract).

- Worker `storage_reader`/`storage_file_reader` and the SaaS Snapshot SP data readers are gated only by the explicit `disable_function_scanning` opt-out (new `local.function_scanning_enabled`), no longer by `upwind_feature_dspm_enabled`.
- New self-hosted `UpwindDSPMEnabled-{org}` marker role + worker assignment per cloudscanner scope when `upwind_feature_dspm_enabled=true` - same naming contract as the SaaS marker in `saas.tf` (`cloudscanner_enabled` is always false in SaaS mode, so the two never overlap).
- `upwind_feature_dspm_enabled` default flips `true` -> `false`: DSPM is opt-in. It is ignored (no marker) when `disable_function_scanning=true`, since DSPM reads data via those grants.
- README regenerated with terraform-docs.

## How CloudScanner's DSPM gate consumes this (confirmed against cloudscanner)

`checkAzureDSPMPermissions` branches on the config's SaaS mode:
- **SaaS** -> marker-role lookup via `SearchAzureRoleDefinitions` (`roleName like "UpwindDSPMEnabled-{orgID}%"`) - the `saas.tf` marker is the live gate signal.
- **Outpost (self-hosted)** -> unchanged: worker managed-identity existence. The outpost gate does **not** read the marker; the new self-hosted marker is a forward-compatible opt-in artifact only. Outpost DSPM compute is controlled by the Upwind-side `FeatureFlagDSPMAzure` (gates the DSPM VMSS via onboarding-service), not by this variable.

## Migration notes for existing module users

- **Self-hosted / outpost orgs: no DSPM regression from the default flip.** The outpost detection path keys on worker-MI existence (which exists whenever CloudScanner is provisioned) and never consulted a marker - before this PR self-hosted had no marker at all. Existing self-hosted DSPM behavior is unchanged by `upwind_feature_dspm_enabled=false`; if anything the storage grants become *more* available (always assigned). Release-note line: "Self-hosted: `upwind_feature_dspm_enabled` now mints an (currently unread) DSPM marker role; DSPM scanning itself follows the Upwind-side feature flag."
- **Customers who previously set `upwind_feature_dspm_enabled=false` to withhold the storage readers** will have those grants re-created on next apply (function scanning is on by default now). The explicit opt-out is `disable_function_scanning=true`. This is the intended semantics change - flag it in release notes.
- **SaaS customers who relied on the old default `true`**: the next apply destroys their `UpwindDSPMEnabled` marker (DSPM turns off for the org, per the SaaS gate above) unless they set `upwind_feature_dspm_enabled=true`. Intended (DSPM becomes opt-in), but needs a release-note callout.
- The marker role itself carries only management-plane `Microsoft.Storage/storageAccounts/read` (no dataActions); when `function_storage_accounts` narrows the data readers, the marker still allows storage-account *enumeration* across the scope - documented inline.

## Test plan

- `terraform validate` passes, `terraform fmt` clean
- terraform-docs regenerated (`make docs` config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)