### PR TITLE
feat(UP-2387): add subscription scope option to SaaS onboarding

### DIFF
--- a/examples/tenant-saas/README.md
+++ b/examples/tenant-saas/README.md
@@ -5,9 +5,31 @@ This example demonstrates secretless SaaS (provider-hosted) onboarding at the te
 ## Features
 
 - **Mode**: SaaS / provider-hosted (`saas_enabled = true`)
-- **Scoping**: Tenant root management group (roles inherited by all subscriptions, current and future)
+- **Scoping**: Tenant, Management Group, or Subscription — same three options as the outpost path (this example uses Tenant)
 - **Secrets**: None — the customer tenant holds no app registration, Key Vault, managed identities, custom roles, or scanner credentials
 - **Upwind API**: None — no Upwind client credentials are required
+
+## Scope options
+
+SaaS supports the same three scoping options as the self-hosted (outpost) path. Pick one:
+
+```hcl
+# 1. Tenant (this example) — roles at the tenant-root management group, inherited by all subscriptions
+azure_tenant_id = "12345678-1234-1234-1234-123456789012"
+
+# 2. Management group — roles at specific management group(s)
+azure_management_group_ids = ["prod-mg", "dev-mg"]   # do NOT set azure_tenant_id
+
+# 3. Subscription — roles scoped to specific subscriptions only
+azure_tenant_id                    = "12345678-1234-1234-1234-123456789012"
+cloudapi_include_subscriptions     = ["<sub-id>"]   # Fetcher (inventory) scope
+cloudscanner_include_subscriptions = ["<sub-id>"]   # Snapshot (scanning) scope
+```
+
+The Snapshot SP (scanning) follows the `cloudscanner_*` filters; the Fetcher SP (inventory) follows
+the `cloudapi_*` filters. Regardless of scope, snapshot **write/delete** is always confined to the
+central snapshots RG in the orchestrator subscription (`customer_snapshot_resource_group`). Use the
+subscription option when the runner has RBAC-admin only on specific subscriptions, not the tenant/MG.
 
 ## Configuration
 

--- a/modules/tenant/saas.tf
+++ b/modules/tenant/saas.tf
@@ -3,31 +3,33 @@
 # In SaaS mode (var.saas_enabled) the customer tenant holds no secrets, managed
 # identities, or compute. The customer consents to Upwind's two multi-tenant app
 # registrations (Snapshot + Fetcher); this materializes their service principals
-# in the customer tenant, which are then granted scoped ARM roles at the
-# tenant-root management group - inherited by every subscription, current and
-# future. The self-hosted resources (app registration, CSPM role assignments,
-# Key Vault, managed identities, custom roles, credential submission) are gated
-# off when saas_enabled is true.
+# in the customer tenant, which are then granted scoped ARM roles. Scope follows
+# the same three options as the outpost path - Tenant (tenant-root MG), Management
+# Group, or Subscription (via the cloudapi_/cloudscanner_ include/exclude filters).
+# The self-hosted resources (app registration, CSPM role assignments, Key Vault,
+# managed identities, custom roles, credential submission) are gated off when
+# saas_enabled is true.
 #
 # The role sets mirror the self-hosted (outpost) principals so the two paths stay
-# in lock-step - the same source of truth (var.azure_roles / var.azure_custom_role_permissions)
-# feeds both. Application translation (from the outpost path / mg-roles.bicep):
-#   service principal (app registration) -> Fetcher SP  (read-level inventory)
-#   worker identity                      -> Snapshot SP (snapshotting)
+# in lock-step - the same source of truth (var.azure_roles / var.azure_custom_role_permissions
+# and the include/exclude subscription filters) feeds both. Application translation
+# (from the outpost path / mg-roles.bicep):
+#   service principal (app registration) -> Fetcher SP  (read-level inventory, cloudapi scope)
+#   worker identity                      -> Snapshot SP (snapshotting, cloudscanner scope)
 #
-# Snapshot write/delete is NOT granted tenant-wide. Only non-destructive roles are
-# assigned at the management group (Reader, read-only CloudScannerTargetRole, worker
-# storage readers, and the Fetcher's read roles). The Snapshot SP's snapshot
-# write/delete (Disk Snapshot Contributor + Data Operator) is confined to a single
-# central snapshots resource group created in the orchestrator subscription. The
-# worker creates each snapshot in that RG, sourcing the customer disk it reads via
-# the MG-wide read grant.
+# Snapshot write/delete is NOT granted at the read scope. Only non-destructive roles
+# are assigned there (Reader, read-only CloudScannerTargetRole, worker storage
+# readers, and the Fetcher's read roles). The Snapshot SP's snapshot write/delete
+# (Disk Snapshot Contributor + Data Operator) is confined to a single central
+# snapshots resource group created in the orchestrator subscription. The worker
+# creates each snapshot in that RG, sourcing the customer disk it reads via the
+# read grant.
 
 locals {
   # --- Snapshot SP (mirrors the outpost worker identity) ---
 
-  # Broad, read-only built-in role at MG scope. Snapshot write/delete is NOT here -
-  # it is confined to the central snapshots RG (see saas_snapshot_write_roles below).
+  # Broad, read-only built-in role at the snapshot (read) scope. Snapshot write/delete
+  # is NOT here - it is confined to the central snapshots RG (see saas_snapshot_write_roles).
   saas_snapshot_roles = ["Reader"]
 
   # Snapshot write/delete roles, assigned ONLY on the central snapshots RG in the
@@ -38,8 +40,8 @@ locals {
   saas_snapshot_resource_group_name = var.customer_snapshot_resource_group != "" ? var.customer_snapshot_resource_group : "upwind-cs-rg-${var.upwind_organization_id}"
 
   # Worker data-plane read roles - mirrors the outpost storage_reader /
-  # storage_file_reader assignments (bicep workerBuiltinRoles). Assigned at MG
-  # scope so the Snapshot SP can read across every subscription in the tenant.
+  # storage_file_reader assignments (bicep workerBuiltinRoles). Assigned at the
+  # snapshot (cloudscanner) scope so the Snapshot SP can read blob/file content there.
   saas_snapshot_worker_roles = ["Storage Blob Data Reader", "Storage File Data Privileged Reader"]
 
   # --- SP materialization ---
@@ -55,18 +57,32 @@ locals {
   saas_snapshot_sp_object_id = var.snapshot_app_service_principal_object_id != "" ? var.snapshot_app_service_principal_object_id : one(azuread_service_principal.saas_snapshot[*].object_id)
   saas_fetcher_sp_object_id  = var.fetcher_app_service_principal_object_id != "" ? var.fetcher_app_service_principal_object_id : one(azuread_service_principal.saas_fetcher[*].object_id)
 
-  # --- Assignment maps (keyed by "scope|role" across the MG scope(s)) ---
+  # --- Scope resolution (Tenant / Management Group / Subscription) ---
+  #
+  # SaaS supports the same three scoping options as the outpost path, reusing the
+  # same inputs so the two stay in lock-step:
+  #   * Tenant       - azure_tenant_id set, no filters  -> tenant-root MG
+  #   * Mgmt group   - azure_management_group_ids set    -> those MGs
+  #   * Subscription - cloudapi_/cloudscanner_include(exclude)_subscriptions set -> those subs
+  # The Snapshot SP (scanning) follows the cloudscanner scope; the Fetcher SP
+  # (inventory) follows the cloudapi scope. Both fall back to the management-group
+  # scope when no subscription filter is set - so Tenant/MG behavior is unchanged.
+  # Snapshot write/delete stays confined to the central RG regardless of scope.
+  saas_snapshot_scopes = local.cloudscanner_scopes   # cloudscanner_iam.tf: include/exclude subs, else MG
+  saas_fetcher_scopes  = local.base_effective_scopes # main.tf: cloudapi include/exclude subs, else MG
 
-  # Snapshot SP built-in roles.
+  # --- Assignment maps (keyed by "scope|role") ---
+
+  # Snapshot SP built-in read roles at the snapshot (cloudscanner) scope(s).
   saas_snapshot_role_assignments = var.saas_enabled ? {
-    for pair in setproduct(local.normalized_management_group_ids, local.saas_snapshot_roles) :
+    for pair in setproduct(local.saas_snapshot_scopes, local.saas_snapshot_roles) :
     "${pair[0]}|${pair[1]}" => { scope = pair[0], role = pair[1] }
   } : {}
 
   # Snapshot SP worker data-plane roles. These back DSPM (blob/file content read), so
   # they are gated on DSPM being enabled (local.dspm_enabled) in addition to saas_enabled.
   saas_snapshot_worker_role_assignments = (var.saas_enabled && local.dspm_enabled) ? {
-    for pair in setproduct(local.normalized_management_group_ids, local.saas_snapshot_worker_roles) :
+    for pair in setproduct(local.saas_snapshot_scopes, local.saas_snapshot_worker_roles) :
     "${pair[0]}|${pair[1]}" => { scope = pair[0], role = pair[1] }
   } : {}
 
@@ -75,24 +91,23 @@ locals {
 
   # DSPM marker role scopes - minted only when DSPM is enabled, alongside the worker
   # data-plane grant above, so "marker exists <=> DSPM provisioned" holds.
-  saas_dspm_marker_scopes = (var.saas_enabled && local.dspm_enabled) ? toset(local.normalized_management_group_ids) : []
+  saas_dspm_marker_scopes = (var.saas_enabled && local.dspm_enabled) ? toset(local.saas_snapshot_scopes) : []
 
   # Snapshot SP CloudScannerTargetRole scopes (target-disk read + begin-access +
   # ACR pull - identical actions to the outpost worker's target role).
-  saas_target_role_scopes = var.saas_enabled ? toset(local.normalized_management_group_ids) : []
+  saas_target_role_scopes = var.saas_enabled ? toset(local.saas_snapshot_scopes) : []
 
   # --- Fetcher SP (mirrors the outpost app-registration SP) ---
 
-  # Fetcher SP built-in read roles (var.azure_roles - same list the outpost app
-  # registration gets; bicep builtinRoles).
+  # Fetcher SP built-in read roles (var.azure_roles) at the fetcher (cloudapi) scope(s).
   saas_fetcher_role_assignments = var.saas_enabled ? {
-    for pair in setproduct(local.normalized_management_group_ids, var.azure_roles) :
+    for pair in setproduct(local.saas_fetcher_scopes, var.azure_roles) :
     "${pair[0]}|${pair[1]}" => { scope = pair[0], role = pair[1] }
   } : {}
 
   # Fetcher SP custom-role scopes (var.azure_custom_role_permissions - same custom
   # role the outpost app registration gets; bicep customRole).
-  saas_fetcher_custom_role_scopes = (var.saas_enabled && length(var.azure_custom_role_permissions) > 0) ? toset(local.normalized_management_group_ids) : []
+  saas_fetcher_custom_role_scopes = (var.saas_enabled && length(var.azure_custom_role_permissions) > 0) ? toset(local.saas_fetcher_scopes) : []
 }
 
 # Materialize the consented service principal for Upwind's Snapshot app reg


### PR DESCRIPTION
## Summary

Adds the **Subscription** scope option to SaaS onboarding, so SaaS now supports the same three scoping choices as the outpost path — matching the product UI (Tenant / Management Group / Subscription). Uses the **existing** `cloudapi_*` / `cloudscanner_*` include/exclude filters — **no new variables**.

## Motivation

Previously the SaaS path ignored the subscription filters and always assigned roles at the management group. A runner with RBAC-admin only on a specific subscription (not the tenant-root MG) hit `403 Forbidden` on `roleAssignments/write` + `roleDefinitions/write` at the MG scope. Now the SaaS roles land on the selected subscription(s) instead.

## How it works

| UI option | Inputs | SaaS scope |
|---|---|---|
| Tenant | `azure_tenant_id`, no filters | tenant-root MG |
| Management Group | `azure_management_group_ids` | those MGs |
| Subscription | `cloudapi_include_subscriptions` + `cloudscanner_include_subscriptions` | those subscriptions |

- **Snapshot SP** (scanning: Reader, CloudScannerTargetRole, worker storage readers, DSPM marker) → `local.cloudscanner_scopes`
- **Fetcher SP** (inventory: built-in reads + custom role) → `local.base_effective_scopes` (cloudapi)
- **Snapshot write/delete** → still confined to the central snapshots RG in the orchestrator subscription, regardless of scope

Both scope locals fall back to `normalized_management_group_ids` when no subscription filter is set, so **Tenant/MG behavior is byte-for-byte unchanged**. This mirrors the outpost path exactly (cloudapi = inventory superset, cloudscanner = scanning subset).

## Changes
- `modules/tenant/saas.tf` — scope resolution rewired to the cloudscanner/cloudapi scope locals
- `examples/tenant-saas/README.md` — documents the three scope options

## Validation
- `terraform fmt` clean; `terraform validate` Success
- No new variables/resources; no behavior change for Tenant/MG scopes

## Related
- Builds on the RG-centralization (PR #87, merged) — snapshot write/delete confinement is unchanged here.
- ARM parity (`onboard.sh`/`.ps1` SaaS subscription route) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)